### PR TITLE
Fix French translation for 'Wires'

### DIFF
--- a/items.json
+++ b/items.json
@@ -1016,7 +1016,7 @@
     "name": {
       "en": "Wires",
       "de": "Kabel",
-      "fr": "Fils",
+      "fr": "Cables",
       "es": "Cables",
       "pt": "Fios",
       "pl": "Przewody",


### PR DESCRIPTION
Updated French translation for 'Wires' from 'Fils' to 'Cables'.