### PR TITLE
Fix wolfpack & wolfpack_blueprint crafting info

### DIFF
--- a/items.json
+++ b/items.json
@@ -4027,7 +4027,12 @@
     "recyclesInto": {
       "crude_explosives": 2,
       "synthesized_fuel": 2
-    }
+    },
+    "recipe": {
+      "explosive_compound": 2,
+      "sensors": 2
+    },
+    "craftBench": "explosives_station"    
   },
   {
     "id": "camera_lens",
@@ -16483,8 +16488,8 @@
     "value": 5000,
     "weightKg": 0.0,
     "rarity": "Common",
-    "recyclesInto": {
-      "explosives_station_iii": 9,
+    "station": "Explosives Station III",
+    "crafting": {
       "explosive_compound": 2,
       "sensors": 2
     },


### PR DESCRIPTION
Wolfpack was missing crafting info entirely. Wolfpack blueprint had crafting costs in recycles into value instead. 

The format for blueprint crafting info is inconsistent in the file, please let me know if I picked the wrong format.