### PR TITLE
Update French translations for quest names

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -1505,7 +1505,7 @@
     "name": {
       "en": "Mixed Signals",
       "de": "Gemischte Signale",
-      "fr": "Signaux brouillés",
+      "fr": "Signaux confus",
       "es": "Señales mixtas",
       "pt": "Sinais misturados",
       "pl": "Mieszane sygnały",
@@ -1526,7 +1526,7 @@
     "description": {
       "en": "Have you spotted any Surveyors; the big round ones? They seem to be transmitting data back into orbit, and I can't help but think it's tied to that signal we picked up. Will you break one open, so we can try to decipher the data?",
       "de": "Hast du irgendwelche Vermesser gesehen; die großen runden? Sie scheinen Daten zurück in den Orbit zu übertragen, und ich kann nicht anders, als zu denken, dass es mit dem Signal zusammenhängt, das wir aufgefangen haben. Würdest du einen aufbrechen, damit wir versuchen können, die Daten zu entschlüsseln?",
-      "fr": "Avez-vous repéré des Arpenteurs ; les gros ronds ? Ils semblent transmettre des données en orbite, et je ne peux m'empêcher de penser que c'est lié au signal que nous avons capté. Pourriez-vous en ouvrir un, pour que nous puissions essayer de déchiffrer les données ?",
+      "fr": "Avez-vous repéré des Guetteurs, ces grosses machines toutes rondes ? Ils semblent transmettre des données en orbite, et je ne peux m'empêcher de penser que c'est lié au signal que nous avons capté. Pourriez-vous en ouvrir un, afin que nous puissions tenter de déchiffrer les données ?",
       "es": "¿Has visto algún Topógrafo; los grandes y redondos? Parecen estar transmitiendo datos de vuelta a la órbita, y no puedo evitar pensar que está relacionado con esa señal que captamos. ¿Podrías abrir uno para que podamos intentar descifrar los datos?",
       "pt": "Você viu algum Topógrafo; aqueles grandes e redondos? Eles parecem estar transmitindo dados de volta para a órbita, e não consigo deixar de pensar que está ligado àquele sinal que captamos. Você poderia abrir um, para que possamos tentar decifrar os dados?",
       "pl": "Widziałeś jakieś Geodety; te duże, okrągłe? Wydają się przesyłać dane z powrotem na orbitę, i nie mogę przestać myśleć, że to związane z tym sygnałem, który przechwyciliśmy. Czy mógłbyś otworzyć jeden, żebyśmy mogli spróbować odszyfrować dane?",
@@ -1547,7 +1547,7 @@
       {
         "en": "Destroy an ARC Surveyor",
         "de": "Zerstöre einen ARC-Vermesser",
-        "fr": "Détruisez un Arpenteur ARC",
+        "fr": "Détruire un Guetteur ARC",
         "es": "Destruye un Topógrafo ARC",
         "pt": "Destrua um Topógrafo ARC",
         "pl": "Zniszcz Geodetę ARC",
@@ -1567,7 +1567,7 @@
       {
         "en": "Obtain 1 Surveyor Vault",
         "de": "Erhalte 1 Vermesser-Tresor",
-        "fr": "Obtenez 1 coffre d'Arpenteur",
+        "fr": "Obtenir 1 coffre de Guetteur",
         "es": "Obtén 1 cámara de Topógrafo",
         "pt": "Obtenha 1 cofre de Topógrafo",
         "pl": "Zdobądź 1 skarbiec Geodety",
@@ -2613,7 +2613,7 @@
     "name": {
       "en": "Keeping the Memory",
       "de": "Die Erinnerung bewahren",
-      "fr": "Préserver la mémoire",
+      "fr": "Conservation mémorielle",
       "es": "Guardando la memoria",
       "pt": "Guardando a memória",
       "pl": "Zachowanie pamięci",
@@ -2634,7 +2634,7 @@
     "description": {
       "en": "I lost my cool a bit when I sent you after that trap. I don't usually lose my temper, but the First Wave... We went through a lot, back then. Lost a lot of people. It's still a bit of a raw wound for me, but I want you to understand.",
       "de": "Ich habe etwas die Fassung verloren, als ich dich wegen dieser Falle losgeschickt habe. Normalerweise verliere ich nicht die Beherrschung, aber die First Wave... Wir haben damals viel durchgemacht. Viele Menschen verloren. Es ist immer noch eine offene Wunde für mich, aber ich möchte, dass du es verstehst.",
-      "fr": "J'ai un peu perdu mon sang-froid quand je t'ai envoyé après ce piège. Je ne perds pas souvent mon calme, mais la First Wave... On a traversé beaucoup d'épreuves, à l'époque. Perdu beaucoup de gens. C'est encore une plaie à vif pour moi, mais je veux que tu comprennes.",
+      "fr": "J'ai un peu perdu mon sang-froid quand je vous ai demandé de vous occuper de ce piège. Ça ne m'arrive pas souvent, mais la Première vague... Nous avons enduré tant de choses à l'époque. Perdu beaucoup de monde. C'est une blessure qui ne se referme pas complètement. Il faut que vous le compreniez.",
       "es": "Perdí un poco la calma cuando te envié tras esa trampa. Normalmente no pierdo los estribos, pero la First Wave... Pasamos por mucho en aquel entonces. Perdimos a mucha gente. Todavía es una herida abierta para mí, pero quiero que lo entiendas.",
       "pt": "Perdi um pouco a calma quando te enviei atrás daquela armadilha. Normalmente não perco a paciência, mas a First Wave... Passámos por muito naquela altura. Perdemos muita gente. Ainda é uma ferida aberta para mim, mas quero que compreendas.",
       "pl": "Trochę straciłem zimną krew, kiedy wysłałem cię po tę pułapkę. Zwykle nie tracę panowania nad sobą, ale First Wave... Przeszliśmy przez wiele wtedy. Straciliśmy wielu ludzi. To wciąż świeża rana dla mnie, ale chcę, żebyś zrozumiał.",
@@ -2655,7 +2655,7 @@
       {
         "en": "Reach the wreckage in the Formicai Hills",
         "de": "Erreiche das Wrack in den Formicai Hills",
-        "fr": "Atteins l'épave dans les Formicai Hills",
+        "fr": "Atteindre l'épave dans les Collines de Formicai",
         "es": "Alcanza los restos en las Formicai Hills",
         "pt": "Alcance os destroços nas Formicai Hills",
         "pl": "Dotrzyj do wraku w Formicai Hills",
@@ -2675,7 +2675,7 @@
       {
         "en": "Search for the missing helmet",
         "de": "Suche nach dem vermissten Helm",
-        "fr": "Cherche le casque manquant",
+        "fr": "Chercher le casque manquant",
         "es": "Busca el casco perdido",
         "pt": "Procure o capacete desaparecido",
         "pl": "Poszukaj zaginionego hełmu",
@@ -2695,7 +2695,7 @@
       {
         "en": "Return the helmet to the memorial",
         "de": "Bringe den Helm zum Denkmal zurück",
-        "fr": "Rapporte le casque au mémorial",
+        "fr": "Rapporter le casque au monument commémoratif",
         "es": "Devuelve el casco al memorial",
         "pt": "Devolva o capacete ao memorial",
         "pl": "Zwróć hełm do pomnika",
@@ -4471,7 +4471,7 @@
     "name": {
       "en": "A Lay of the Land",
       "de": "Eine Übersicht des Geländes",
-      "fr": "Une vue du terrain",
+      "fr": "Un aperçu du terrain",
       "es": "Un reconocimiento del terreno",
       "pt": "Um reconhecimento do terreno",
       "pl": "Rozpoznanie terenu",
@@ -4514,7 +4514,7 @@
       {
         "en": "Reach the Jiangsu Warehouse",
         "de": "Erreiche das Jiangsu-Lagerhaus",
-        "fr": "Atteignez l'entrepôt de Jiangsu",
+        "fr": "Atteindre l'Entrepôt Jiangsu",
         "es": "Llega al almacén de Jiangsu",
         "pt": "Alcance o armazém de Jiangsu",
         "pl": "Dotrzyj do magazynu Jiangsu",


### PR DESCRIPTION
Hello, as you can see inside the game, the translations aren't the same in french :

<img width="418" height="292" alt="image" src="https://github.com/user-attachments/assets/29b68935-02ea-4354-aa48-85021da1ef31" />


There might be other descriptions fixes.

EDIT : Added other fixes to match in game translation.
EDIT 2: Rebased commits