### PR TITLE
Add light ammo rarity

### DIFF
--- a/items/light_ammo.json
+++ b/items/light_ammo.json
@@ -41,6 +41,7 @@
     "sr": "Laki meci koji se uglavnom koriste sa automatskim pištoljima i lakim pištoljima. Kompatibilno sa: Burletta, Stitcher, Kettle, Hairpin, Bobcat"
   },
   "type": "Ammunition",
+  "rarity": "Common",
   "imageFilename": "https://cdn.arctracker.io/items/light_ammo.png",
   "compatibleWith": [
     "Kettle",


### PR DESCRIPTION
Fixes light ammo being the only item in the data not having a rarity defined, when it should be `Common`.