### PR TITLE
Update mechanical_components.json with latest recycling recipe

### DIFF
--- a/items/mechanical_components.json
+++ b/items/mechanical_components.json
@@ -44,11 +44,11 @@
   "rarity": "Uncommon",
   "value": 640,
   "recyclesInto": {
-    "metal_parts": 8,
-    "steel_spring": 2
+    "metal_parts": 3,
+    "rubber_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/mechanical_components.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "11/23/2025",
   "weightKg": 0.5,
   "stackSize": 10,
   "foundIn": "Mechanical",


### PR DESCRIPTION
Updated recycling values for Mechanical Components. It recycles into 3 Metal Parts & 2 Rubber.
<img width="738" height="281" alt="Recycle Mechanical Components" src="https://github.com/user-attachments/assets/92fe026f-16c5-4644-9cf7-71a6517a8d26" />
