### PR TITLE
fix trades.json itemId from 'spring' to 'steel_spring'

### DIFF
--- a/trades.json
+++ b/trades.json
@@ -251,7 +251,7 @@
   },
   {
     "trader": "Celeste",
-    "itemId": "spring",
+    "itemId": "steel_spring",
     "quantity": 1,
     "cost": {
       "itemId": "assorted_seeds",


### PR DESCRIPTION
Fixes the remaining discrepancy in #69 
The correct item id is `steel_spring` per `items/steel_spring.json`