### PR TITLE
Updated the upgradeCost for Ferro, Burletta, and Hairpin

### DIFF
--- a/items/burletta_ii.json
+++ b/items/burletta_ii.json
@@ -44,10 +44,14 @@
   "rarity": "Uncommon",
   "value": 5000,
   "weightKg": 4,
+  "upgradeCost": {
+    "mechanical_components": 3,
+    "simple_gun_parts": 1
+  },
   "recyclesInto": {
     "mechanical_components": 2,
     "simple_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "11/24/2025"
 }

--- a/items/burletta_iii.json
+++ b/items/burletta_iii.json
@@ -44,10 +44,14 @@
   "rarity": "Uncommon",
   "value": 7000,
   "weightKg": 4,
+  "upgradeCost": {
+    "mechanical_components": 3,
+    "simple_gun_parts": 1
+  },
   "recyclesInto": {
     "mechanical_components": 3,
     "simple_gun_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "11/24/2025"
 }

--- a/items/burletta_iv.json
+++ b/items/burletta_iv.json
@@ -42,12 +42,16 @@
   },
   "type": "Pistol",
   "rarity": "Uncommon",
-  "value": 9000,
+  "value": 10000,
   "weightKg": 4,
+  "upgradeCost": {
+    "mechanical_components": 4,
+    "light_gun_parts": 1
+  },
   "recyclesInto": {
     "mechanical_components": 4,
     "simple_gun_parts": 4
   },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "11/24/2025"
 }

--- a/items/ferro_ii.json
+++ b/items/ferro_ii.json
@@ -151,7 +151,14 @@
       "value": "Strong"
     }
   },
+  "upgradeCost": {
+    "metal_parts": 7
+  },
+  "recyclesInto": {
+    "metal_parts": 4,
+    "simple_gun_parts": 3
+  },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "10/31/2025",
+  "updatedAt": "11/24/2025",
   "isWeapon": true
 }

--- a/items/ferro_iii.json
+++ b/items/ferro_iii.json
@@ -173,13 +173,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "11/17/2025",
+  "updatedAt": "11/24/2025",
   "recyclesInto": {
     "metal_parts": 6,
     "simple_gun_parts": 1
   },
   "upgradeCost": {
-    "mechanical_components": 1,
+    "metal_parts": 9,
     "simple_gun_parts": 1
   },
   "isWeapon": true

--- a/items/ferro_iv.json
+++ b/items/ferro_iv.json
@@ -55,8 +55,12 @@
   "salvagesInto": {
     "metal_parts": 2
   },
+  "upgradeCost": {
+    "mechanical_components": 1,
+    "simple_gun_parts": 1
+  },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "11/24/2025",
   "weightKg": 8,
   "effects": {
     "Durability": {

--- a/items/hairpin_iii.json
+++ b/items/hairpin_iii.json
@@ -215,7 +215,7 @@
   "weightKg": 3,
   "value": 2000,
   "imageFilename": "https://cdn.arctracker.io/items/hairpin_i.png",
-  "updatedAt": "11/11/2025",
+  "updatedAt": "11/24/2025",
   "recyclesInto": {
     "metal_parts": 6,
     "simple_gun_parts": 1
@@ -225,7 +225,7 @@
   },
   "craftBench": "weapon_bench",
   "upgradeCost": {
-    "metal_parts": 6,
+    "metal_parts": 9,
     "simple_gun_parts": 1
   },
   "isWeapon": true


### PR DESCRIPTION
Updated values for Burletta:
<img width="446" height="874" alt="burletta_i to burletta_ii" src="https://github.com/user-attachments/assets/ce0cee40-efa4-4cbd-90e1-b544a5f1bff3" />
<img width="452" height="871" alt="burletta_ii to burletta_iii" src="https://github.com/user-attachments/assets/6af13d2c-6107-4d73-9070-708373cdb6f7" />
<img width="446" height="875" alt="burletta_iii to burletta_iv" src="https://github.com/user-attachments/assets/73c4f5d0-077a-4cf1-8fc3-2d63379e68f8" />
<img width="421" height="384" alt="burletta_iv sale price" src="https://github.com/user-attachments/assets/4c06387e-2900-4c2c-b1de-3a6883a8b284" />

Updated values for Ferro:
<img width="448" height="871" alt="ferro_i to ferro_ii" src="https://github.com/user-attachments/assets/763d8dc3-98f8-40fa-bf75-ee86434d778b" />
<img width="458" height="870" alt="ferro_ii to ferro_iii" src="https://github.com/user-attachments/assets/c8289c6f-4f19-4bab-a671-ad9f3df5df92" />
<img width="449" height="871" alt="ferro_iii to ferro_iv" src="https://github.com/user-attachments/assets/3c3bd799-e082-4b4d-99ec-b20d400476d0" />
<img width="736" height="273" alt="ferro_ii recycle" src="https://github.com/user-attachments/assets/b7e6e2c6-a549-4528-8a5c-49a9b3a8511b" />
<img width="410" height="561" alt="ferro_ii value" src="https://github.com/user-attachments/assets/a8af8137-2ad6-49e0-9795-061ce0a6acd5" />
<img width="743" height="263" alt="ferro_iv recycle" src="https://github.com/user-attachments/assets/7b59d6da-2bbf-4544-a70c-912654df4466" />

Updated values for Hairpin:
<img width="453" height="939" alt="hairpin_ii to hairpin_iii" src="https://github.com/user-attachments/assets/322e405e-a638-4db6-b939-578128b54880" />
