### PR TITLE
fix: corrects the `canister` pt translation

### DIFF
--- a/items/canister.json
+++ b/items/canister.json
@@ -5,7 +5,7 @@
     "de": "Kanister",
     "fr": "Bonbonne",
     "es": "Bidón",
-    "pt": "Recipiente",
+    "pt": "Vasilhame",
     "pl": "Kanister",
     "no": "Beholder",
     "da": "Beholder",


### PR DESCRIPTION
<img width="679" height="522" alt="image" src="https://github.com/user-attachments/assets/b99c118f-b445-410e-a3b3-ce118696785d" />