### PR TITLE
change rusty_arc_steel weight property to weightKg to match all other items

### DIFF
--- a/items/rusty_arc_steel.json
+++ b/items/rusty_arc_steel.json
@@ -42,7 +42,7 @@
   },
   "type": "Recyclable",
   "rarity": "Uncommon",
-  "weight": 1,
+  "weightKg": 1,
   "stackSize": 3,
   "value": 640,
   "foundIn": "ARC",


### PR DESCRIPTION
rusty_arc_steel weight property was mismatched. Every other item uses weightKg so I have updated it

Example: "rusted_tools"
``` json
{
  "id": "rusted_tools",
  ...
  "weightKg": 2
  ...
}
```