### PR TITLE
fix: Correct wrong ID used for the recyclesInto

### DIFF
--- a/items/magnetron.json
+++ b/items/magnetron.json
@@ -50,6 +50,6 @@
   "value": 6000,
   "recyclesInto": {
     "magnetic_accelerator": 1,
-    "spring": 1
+    "steel_spring": 1
   }
 }


### PR DESCRIPTION
Fixes the id from `spring` to `steel_spring` on Magnetron