### PR TITLE
Update recycle item name from 'spring' to 'steel_spring'

### DIFF
--- a/items/magnetron.json
+++ b/items/magnetron.json
@@ -50,6 +50,6 @@
   "value": 6000,
   "recyclesInto": {
     "magnetic_accelerator": 1,
-    "spring": 1
+    "steel_spring": 1
   }
 }


### PR DESCRIPTION
Magnetron lists spring but the item is steel_spring