### PR TITLE
fix(quests): ✏️ update French translations for various quests

### DIFF
--- a/deprecated/quests.json
+++ b/deprecated/quests.json
@@ -105,7 +105,7 @@
     "name": {
       "en": "Clearer Skies",
       "de": "Klarere Himmel",
-      "fr": "Cieux plus clairs",
+      "fr":"Ciel dégagé",
       "es": "Cielos despejados",
       "pt": "Céus mais claros",
       "pl": "Jaśniejsze niebo",
@@ -195,7 +195,7 @@
     "name": {
       "en": "Trash Into Treasure",
       "de": "Müll zu Schätzen",
-      "fr": "Des déchets aux trésors",
+      "fr": "Déchets précieux",
       "es": "Basura valiosa",
       "pt": "Lixo em tesouro",
       "pl": "Ze śmieci w skarb",
@@ -285,7 +285,7 @@
     "name": {
       "en": "Off The Radar",
       "de": "Unter dem Radar",
-      "fr": "Hors radar",
+      "fr": "Hors du radar",
       "es": "Fuera del radar",
       "pt": "Fora do radar",
       "pl": "Poza radarem",
@@ -509,7 +509,7 @@
     "name": {
       "en": "Down To Earth",
       "de": "Zurück auf dem Boden",
-      "fr": "Les pieds sur terre",
+      "fr": "Retour sur terre",
       "es": "Pies en la tierra",
       "pt": "De volta à terra",
       "pl": "Z powrotem na ziemię",
@@ -803,7 +803,7 @@
     "name": {
       "en": "What Goes Around",
       "de": "Was herumgeht",
-      "fr": "Tout finit par revenir",
+      "fr":"Qui sème le vent",
       "es": "Todo lo que va",
       "pt": "O que vai, volta",
       "pl": "Co się odwlecze",
@@ -1191,7 +1191,7 @@
     "name": {
       "en": "A Better Use",
       "de": "Eine bessere Verwendung",
-      "fr": "Une meilleure utilisation",
+      "fr":"Un meilleur usage",
       "es": "Un mejor uso",
       "pt": "Um uso melhor",
       "pl": "Lepsze zastosowanie",
@@ -1425,7 +1425,7 @@
     "name": {
       "en": "Dormant Barons",
       "de": "Ruhende Barone",
-      "fr": "Barons dormants",
+      "fr": "Barons latents",
       "es": "Barones durmientes",
       "pt": "Barões adormecidos",
       "pl": "Uśpieni Baronowie",
@@ -1621,7 +1621,7 @@
     "name": {
       "en": "What We Left Behind",
       "de": "Was wir zurückgelassen haben",
-      "fr": "Ce que nous avons laissé derrière",
+      "fr": "Ce que nous avons laissé derrière nous",
       "es": "Lo que dejamos atrás",
       "pt": "O que deixamos para trás",
       "pl": "Co zostawiliśmy za sobą",
@@ -1963,7 +1963,7 @@
     "name": {
       "en": "Marked for Death",
       "de": "Zum Tode verurteilt",
-      "fr": "Marqué pour la mort",
+      "fr":"Condamnation",
       "es": "Marcado para morir",
       "pt": "Marcado para a morte",
       "pl": "Naznaczony śmiercią",
@@ -2423,7 +2423,7 @@
     "name": {
       "en": "Straight Record",
       "de": "Klare Verhältnisse",
-      "fr": "Remettre les pendules à l'heure",
+      "fr":"Enregistrement direct",
       "es": "Registro limpio",
       "pt": "Registro limpo",
       "pl": "Czyste konto",
@@ -3055,7 +3055,7 @@
     "name": {
       "en": "A Symbol of Unification",
       "de": "Ein Symbol der Einheit",
-      "fr": "Un symbole d'unification",
+      "fr": "Un symbole d'union",
       "es": "Un símbolo de unificación",
       "pt": "Um símbolo de unificação",
       "pl": "Symbol zjednoczenia",
@@ -3969,7 +3969,7 @@
     "name": {
       "en": "Out of the Shadows",
       "de": "Aus den Schatten",
-      "fr": "Hors de l'ombre",
+      "fr": "Hors des ombres",
       "es": "Saliendo de las sombras",
       "pt": "Fora das sombras",
       "pl": "Z cienia",
@@ -4746,7 +4746,7 @@
     "name": {
       "en": "After Rain Comes",
       "de": "Nach dem Regen kommt",
-      "fr": "Après la pluie vient",
+      "fr": "Ensoleillement vient",
       "es": "Después de la lluvia viene",
       "pt": "Depois da chuva vem",
       "pl": "Po deszczu przychodzi",
@@ -5598,7 +5598,7 @@
     "name": {
       "en": "Switching the Supply",
       "de": "Umstellung der Versorgung",
-      "fr": "Changer l'approvisionnement",
+      "fr":"Problèmes d'alimentation",
       "es": "Cambiar el suministro",
       "pt": "Mudar o Abastecimento",
       "pl": "Zmiana zaopatrzenia",
@@ -5702,7 +5702,7 @@
     "name": {
       "en": "A Warm Place to Rest",
       "de": "Ein warmer Ort zum Ausruhen",
-      "fr": "Un endroit chaud pour se reposer",
+      "fr": "Un nid douillet",
       "es": "Un lugar cálido para descansar",
       "pt": "Um Lugar Quente para Descansar",
       "pl": "Ciepłe miejsce na odpoczynek",
@@ -6378,7 +6378,7 @@
     "name": {
       "en": "Espresso",
       "de": "Espresso",
-      "fr": "Espresso",
+      "fr":"Expresso",
       "es": "Espresso",
       "pt": "Espresso",
       "pl": "Espresso",
@@ -6420,7 +6420,7 @@
       {
         "en": "Find an espresso machine to salvage for spare parts",
         "de": "Finde eine Espressomaschine, um Ersatzteile zu bergen",
-        "fr": "Trouvez une machine à espresso à récupérer pour des pièces détachées",
+        "fr":"Trouvez une machine à expresso à récupérer pour des pièces détachées",
         "es": "Encuentra una máquina de espresso para recuperar piezas de repuesto",
         "pt": "Encontre uma máquina de espresso para recuperar peças sobressalentes",
         "pl": "Znajdź ekspres do kawy, aby odzyskać części zamienne",
@@ -6440,7 +6440,7 @@
       {
         "en": "Get the Espresso Machine Parts for Apollo",
         "de": "Besorge die Espressomaschinen-Teile für Apollo",
-        "fr": "Obtenez les pièces de la machine à espresso pour Apollo",
+        "fr":"Obtenez les pièces de la machine à expresso pour Apollo",
         "es": "Consigue las piezas de la máquina de espresso para Apollo",
         "pt": "Consiga as peças da máquina de espresso para Apollo",
         "pl": "Zdobądź części ekspresu do kawy dla Apollo",
@@ -6478,7 +6478,7 @@
     "name": {
       "en": "Life of a Pharmacist",
       "de": "Leben eines Apothekers",
-      "fr": "Vie d'un pharmacien",
+      "fr":"La La vie d'un pharmacien",
       "es": "Vida de un farmacéutico",
       "pt": "Vida de um farmacêutico",
       "pl": "Życie farmaceuty",
@@ -6642,7 +6642,7 @@
     "name": {
       "en": "Tribute to Toledo",
       "de": "Tribut an Toledo",
-      "fr": "Tribut à Toledo",
+      "fr": "Hommage à Toledo",
       "es": "Tributo a Toledo",
       "pt": "Tributo a Toledo",
       "pl": "Trybut dla Toledo",
@@ -7497,7 +7497,7 @@
     "name": {
       "en": "Reduced to Rubble",
       "de": "Zu Schutt reduziert",
-      "fr": "Réduit en décombres",
+      "fr": "Chemin de destruction",
       "es": "Reducido a escombros",
       "pt": "Reduzido a escombros",
       "pl": "Obrócone w gruzy",

--- a/quests/a_better_use.json
+++ b/quests/a_better_use.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "A Better Use",
     "de": "Eine bessere Verwendung",
-    "fr": "Une meilleure utilisation",
+    "fr": "Un meilleur usage",
     "es": "Un mejor uso",
     "pt": "Um uso melhor",
     "pl": "Lepsze zastosowanie",

--- a/quests/a_symbol_of_unification.json
+++ b/quests/a_symbol_of_unification.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "A Symbol of Unification",
     "de": "Ein Symbol der Einheit",
-    "fr": "Un symbole d'unification",
+    "fr": "Un symbole d'union",
     "es": "Un símbolo de unificación",
     "pt": "Um símbolo de unificação",
     "pl": "Symbol zjednoczenia",

--- a/quests/a_warm_place_to_rest.json
+++ b/quests/a_warm_place_to_rest.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "A Warm Place to Rest",
     "de": "Ein warmer Ort zum Ausruhen",
-    "fr": "Un endroit chaud pour se reposer",
+    "fr": "Un nid douillet",
     "es": "Un lugar cálido para descansar",
     "pt": "Um Lugar Quente para Descansar",
     "pl": "Ciepłe miejsce na odpoczynek",

--- a/quests/after_rain_comes.json
+++ b/quests/after_rain_comes.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "After Rain Comes",
     "de": "Nach dem Regen kommt",
-    "fr": "Après la pluie",
+    "fr": "Ensoleillement",
     "es": "Después de la lluvia viene",
     "pt": "Depois da chuva vem",
     "pl": "Po deszczu przychodzi",

--- a/quests/clearer_skies.json
+++ b/quests/clearer_skies.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Clearer Skies",
     "de": "Klarer Himmel",
-    "fr": "Cieux plus clairs",
+    "fr": "Ciel dégagé",
     "es": "Cielos despejados",
     "pt": "Céus mais claros",
     "pl": "Jaśniejsze niebo",

--- a/quests/dormant_barons.json
+++ b/quests/dormant_barons.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Dormant Barons",
     "de": "Schlafende Barone",
-    "fr": "Barons dormants",
+    "fr": "Barons latents",
     "es": "Barones durmientes",
     "pt": "Barões adormecidos",
     "pl": "Uśpieni Baronowie",

--- a/quests/down_to_earth.json
+++ b/quests/down_to_earth.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Down To Earth",
     "de": "Bodenständig",
-    "fr": "Les pieds sur terre",
+    "fr": "Retour sur terre",
     "es": "Pies en la tierra",
     "pt": "De volta à terra",
     "pl": "Z powrotem na ziemię",

--- a/quests/espresso.json
+++ b/quests/espresso.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Espresso",
     "de": "Espresso",
-    "fr": "Espresso",
+    "fr": "Expresso",
     "es": "Espresso",
     "pt": "Espresso",
     "pl": "Espresso",
@@ -49,7 +49,7 @@
     {
       "en": "Find an espresso machine to salvage for spare parts",
       "de": "Finde eine Espressomaschine, um Ersatzteile zu bergen",
-      "fr": "Trouvez une machine à espresso à récupérer pour des pièces détachées",
+      "fr": "Trouvez une machine à expresso à récupérer pour des pièces détachées",
       "es": "Encuentra una máquina de espresso para recuperar piezas de repuesto",
       "pt": "Encontre uma máquina de espresso para recuperar peças sobressalentes",
       "pl": "Znajdź ekspres do kawy, aby odzyskać części zamienne",
@@ -69,7 +69,7 @@
     {
       "en": "Get the Espresso Machine Parts for Apollo",
       "de": "Besorge die Espressomaschinen-Teile für Apollo",
-      "fr": "Obtenez les pièces de la machine à espresso pour Apollo",
+      "fr":"Obtenez les pièces de la machine à Expresso pour Apollo",
       "es": "Consigue las piezas de la máquina de espresso para Apollo",
       "pt": "Consiga as peças da máquina de espresso para Apollo",
       "pl": "Zdobądź części ekspresu do kawy dla Apollo",

--- a/quests/life_of_a_pharmacist.json
+++ b/quests/life_of_a_pharmacist.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Life of a Pharmacist",
     "de": "Leben eines Apothekers",
-    "fr": "Vie d'un pharmacien",
+    "fr": "La vie d'un pharmacien",
     "es": "Vida de un farmacéutico",
     "pt": "Vida de um farmacêutico",
     "pl": "Życie farmaceuty",

--- a/quests/marked_for_death.json
+++ b/quests/marked_for_death.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Marked for Death",
     "de": "Zum Tode verurteilt",
-    "fr": "Marqué pour la mort",
+    "fr": "Condamnation",
     "es": "Marcado para morir",
     "pt": "Marcado para a morte",
     "pl": "Naznaczony śmiercią",

--- a/quests/off_the_radar.json
+++ b/quests/off_the_radar.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Off The Radar",
     "de": "Unter dem Radar",
-    "fr": "Hors radar",
+    "fr": "Hors du radar",
     "es": "Fuera del radar",
     "pt": "Fora do radar",
     "pl": "Poza radarem",

--- a/quests/out_of_the_shadows.json
+++ b/quests/out_of_the_shadows.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Out of the Shadows",
     "de": "Aus den Schatten",
-    "fr": "Hors de l'ombre",
+    "fr": "Hors des ombres",
     "es": "Saliendo de las sombras",
     "pt": "Fora das sombras",
     "pl": "Z cienia",

--- a/quests/prescriptions_of_the_past.json
+++ b/quests/prescriptions_of_the_past.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Prescriptions of the Past",
     "de": "Rezepte der Vergangenheit",
-    "fr": "Prescriptions du passé",
+    "fr": "Prescriptions passées",
     "es": "Recetas del pasado",
     "pt": "Prescrições do Passado",
     "pl": "Recepty z przeszłości",

--- a/quests/reduced_to_rubble.json
+++ b/quests/reduced_to_rubble.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Reduced to Rubble",
     "de": "Schutt und Asche",
-    "fr": "Réduit en décombres",
+    "fr": "Chemin de destruction",
     "es": "Reducido a escombros",
     "pt": "Reduzido a escombros",
     "pl": "Obrócone w gruzy",

--- a/quests/snap_and_salvage.json
+++ b/quests/snap_and_salvage.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Snap and Salvage",
     "de": "Schnappen und Ausschlachten",
-    "fr": "Clic et récupération",
+    "fr": "Démolir et recycler",
     "es": "Disparo y rescate",
     "pt": "Clique e Sucata",
     "pl": "Fotka i złom",

--- a/quests/straight_record.json
+++ b/quests/straight_record.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Straight Record",
     "de": "Gute Aufnahme",
-    "fr": "Remettre les pendules à l'heure",
+    "fr":"Enregistrement direct",
     "es": "Registro limpio",
     "pt": "Registro limpo",
     "pl": "Czyste konto",

--- a/quests/switching_the_supply.json
+++ b/quests/switching_the_supply.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Switching the Supply",
     "de": "Umstellung der Versorgung",
-    "fr": "Changer l'approvisionnement",
+    "fr": "Problèmes d'alimentation",
     "es": "Cambiar el suministro",
     "pt": "Mudar o Abastecimento",
     "pl": "Zmiana zaopatrzenia",

--- a/quests/trash_into_treasure.json
+++ b/quests/trash_into_treasure.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Trash Into Treasure",
     "de": "Des einen Müll ist des anderen Schatz",
-    "fr": "Des déchets aux trésors",
+    "fr": "Déchets précieux",
     "es": "Basura valiosa",
     "pt": "Lixo em tesouro",
     "pl": "Ze śmieci w skarb",

--- a/quests/tribute_to_toledo.json
+++ b/quests/tribute_to_toledo.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "Tribute to Toledo",
     "de": "Tribut an Toledo",
-    "fr": "Tribut à Toledo",
+    "fr": "Hommage à Toledo",
     "es": "Tributo a Toledo",
     "pt": "Tributo a Toledo",
     "pl": "Trybut dla Toledo",

--- a/quests/what_goes_around.json
+++ b/quests/what_goes_around.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "What Goes Around",
     "de": "Alles rächt sich",
-    "fr": "Tout finit par revenir",
+    "fr": "Qui sème le vent",
     "es": "Todo lo que va",
     "pt": "O que vai, volta",
     "pl": "Co się odwlecze",

--- a/quests/what_we_left_behind.json
+++ b/quests/what_we_left_behind.json
@@ -4,7 +4,7 @@
   "name": {
     "en": "What We Left Behind",
     "de": "Was wir zurückließen",
-    "fr": "Ce que nous avons laissé derrière",
+    "fr": "Ce que nous avons laissé derrière nous",
     "es": "Lo que dejamos atrás",
     "pt": "O que deixamos para trás",
     "pl": "Co zostawiliśmy za sobą",


### PR DESCRIPTION
* Improved translations for quest names in French to enhance localization accuracy.
* Adjusted phrases for clarity and cultural relevance.

Clic et récupération → Démolir et recycler
Tribut à Toledo → Hommage à Toledo
Après la pluie → Ensoleillement
Réduit en décombres → Chemin de destruction
Hors de l'ombre → Hors des ombres
Prescriptions du passé → Prescriptions passées
Un symbole d'unification → Un symbole d'union
Un endroit chaud pour se reposer → Un nid douillet
Hors radar → Hors du radar
Ce que nous avons laissé derrière → Ce que nous avons laissé derrière nous
Les pieds sur terre → Retour sur terre
Des déchets aux trésors → Déchets précieux
Remettre les pendules à l'heure → Enregistrement direct
Cieux plus clairs → Ciel dégagé
Une meilleure utilisation → Un meilleur usage
Vie d'un pharmacien → La vie d'un pharmacien
Marqué pour la mort → Condamnation
Tout finit par revenir → Qui sème le vent
Espresso → Expresso
Changer l'approvisionnement → Problèmes d'alimentation
Barons dormants → Barons latents

Request from **haveac00kie** (Arktracker.io discord)