### PR TITLE
FIX: Remove bad fields from bettina_blueprint.json

### DIFF
--- a/items/bettina_blueprint.json
+++ b/items/bettina_blueprint.json
@@ -44,12 +44,6 @@
   "value": 5000,
   "weightKg": 0,
   "rarity": "Legendary",
-  "station": "Gunsmith III",
-  "recipe": {
-    "advanced_mechanical_components": 3,
-    "heavy_gun_parts": 3,
-    "canister": 3
-  },
   "imageFilename": "https://cdn.arctracker.io/items/bettina_blueprint.png",
-  "updatedAt": "11/05/2025"
+  "updatedAt": "12/07/2025"
 }


### PR DESCRIPTION
This PR removes the `station` (AKA `craftBench`) and `recipe` fields from `bettina_blueprint.json`. No other Blueprint-type items contain these fields, as blueprints are not craftable.