### PR TITLE
FIX: Update Snap Hook recipe

### DIFF
--- a/items/snap_hook.json
+++ b/items/snap_hook.json
@@ -90,7 +90,8 @@
     }
   },
   "recipe": {
-    "power_rod": 1,
+    "power_rod": 2,
+    "rope": 3,
     "exodus_modules": 1
   },
   "recyclesInto": {
@@ -98,5 +99,5 @@
     "rope": 3
   },
   "craftBench": "utility_bench",
-  "updatedAt": "11/05/2025"
+  "updatedAt": "12/07/2025"
 }


### PR DESCRIPTION
This PR updates `snap_hook.json` with the latest `recipe`.

This is the recipe currently seen in-game.
<img width="375" alt="PioneerGame_ljZ65vJ5s3" src="https://github.com/user-attachments/assets/dce38b6c-06c1-4382-b697-d199dbec7e3b" />
