### PR TITLE
FIX: Update Raider Hatch Key value

### DIFF
--- a/items/raider_hatch_key.json
+++ b/items/raider_hatch_key.json
@@ -42,7 +42,7 @@
     "sr": "Otključava Rejderski Otvor."
   },
   "rarity": "Rare",
-  "value": 1000,
+  "value": 2000,
   "recyclesInto": {},
   "weightKg": 0.01,
   "stackSize": 1,


### PR DESCRIPTION
This PR updates `raider_hatch_key.json` with the latest `value`.

This is the value currently seen in-game.
<img width="400" alt="PioneerGame_zLVbzn0ZQf" src="https://github.com/user-attachments/assets/929b190a-5dcc-4688-bb07-df32637408a8" />

And `updatedAt` is already `12/07/2025` so no need to update that.

(It looks like this value was fixed in [this PR](https://github.com/RaidTheory/arcraiders-data/pull/129), but was undone by [this commit](https://github.com/RaidTheory/arcraiders-data/commit/adeefaec90f9a183888dd37edba63a466b56e38c).)
