### PR TITLE
FIX + FEAT: Update value and weight of ammo, add "craftQuantity" field

### DIFF
--- a/items/energy_clip.json
+++ b/items/energy_clip.json
@@ -46,14 +46,15 @@
     "Jupiter"
   ],
   "imageFilename": "https://cdn.arctracker.io/items/energy_clip.png",
-  "value": 5,
+  "value": 1000,
   "weightKg": 0.3,
   "stackSize": 5,
   "rarity": "Rare",
-  "updatedAt": "11/11/2025",
+  "updatedAt": "12/07/2025",
   "recipe": {
     "advanced_arc_powercell": 1,
     "battery": 2
   },
-  "craftBench": "workbench"
+  "craftBench": "workbench",
+  "craftQuantity": 5
 }

--- a/items/heavy_ammo.json
+++ b/items/heavy_ammo.json
@@ -46,7 +46,7 @@
     "Ferro",
     "Bettina"
   ],
-  "updatedAt": "11/03/2025",
+  "updatedAt": "12/07/2025",
   "value": 12,
   "weightKg": 0.05,
   "stackSize": 40,
@@ -56,5 +56,6 @@
     "metal_parts": 3,
     "chemicals": 2
   },
-  "craftBench": "workbench"
+  "craftBench": "workbench",
+  "craftQuantity": 10
 }

--- a/items/launcher_ammo.json
+++ b/items/launcher_ammo.json
@@ -49,10 +49,11 @@
   "weightKg": 0.1,
   "stackSize": 24,
   "imageFilename": "https://cdn.arctracker.io/items/launcher_ammo.png",
-  "updatedAt": "11/20/2025",
+  "updatedAt": "12/07/2025",
   "recipe": {
     "arc_motion_core": 1,
     "crude_explosives": 2
   },
-  "craftBench": "workbench"
+  "craftBench": "workbench",
+  "craftQuantity": 6
 }

--- a/items/light_ammo.json
+++ b/items/light_ammo.json
@@ -50,13 +50,14 @@
     "Bobcat",
     "Stitcher"
   ],
-  "value": 0.76,
-  "weightKg": 0.00323,
+  "value": 4,
+  "weightKg": 0.017,
   "stackSize": 100,
-  "updatedAt": "11/03/2025",
+  "updatedAt": "12/07/2025",
   "recipe": {
     "metal_parts": 3,
     "chemicals": 2
   },
-  "craftBench": "workbench"
+  "craftBench": "workbench",
+  "craftQuantity": 25
 }

--- a/items/medium_ammo.json
+++ b/items/medium_ammo.json
@@ -53,10 +53,11 @@
   "weightKg": 0.025,
   "stackSize": 80,
   "rarity": "Common",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "12/07/2025",
   "recipe": {
     "metal_parts": 3,
     "chemicals": 2
   },
-  "craftBench": "workbench"
+  "craftBench": "workbench",
+  "craftQuantity": 20
 }

--- a/items/shotgun_ammo.json
+++ b/items/shotgun_ammo.json
@@ -50,10 +50,11 @@
   "stackSize": 20,
   "imageFilename": "https://cdn.arctracker.io/items/shotgun_ammo.png",
   "rarity": "Common",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "12/07/2025",
   "recipe": {
     "metal_parts": 3,
     "chemicals": 2
   },
-  "craftBench": "workbench"
+  "craftBench": "workbench",
+  "craftQuantity": 5
 }


### PR DESCRIPTION
This PR updates incorrect fields on the Ammunition-type items and adds a new `craftQuantity` field to them. This new field clarifies how much of the item is crafted when the given `recipe` is used.

This is the information currently seen in-game.
### Energy Clip
<img width="400" alt="PioneerGame_xzSiEcKxRB" src="https://github.com/user-attachments/assets/2d0c34b4-105e-43e2-a4a0-df1c493237fb" />

### LauncherAmmo
<img width="400" alt="PioneerGame_l12at1RTcL" src="https://github.com/user-attachments/assets/ed061c38-9584-41fa-9261-b3713977c60f" />

### Heavy Ammo
<img width="400" alt="PioneerGame_W03SJCUpSP" src="https://github.com/user-attachments/assets/e05aaff7-2e19-4211-a799-0d1314cdead5" />

### Light Ammo
<img width="400" alt="PioneerGame_JlUopigC7Q" src="https://github.com/user-attachments/assets/a5846189-0e87-4b13-a0af-9f379cef17a0" />

### Medium Ammo
<img width="400" alt="PioneerGame_KY4TKCJGcJ" src="https://github.com/user-attachments/assets/5245edeb-f85b-4016-832b-5e00940780ed" />

### Shotgun Ammo
<img width="400" alt="PioneerGame_MWOBaDtNJi" src="https://github.com/user-attachments/assets/f9309904-d039-4733-be74-4f70935f7011" />
