### PR TITLE
fix: correct required item quantities for the_trifecta quest

### DIFF
--- a/quests/the_trifecta.json
+++ b/quests/the_trifecta.json
@@ -167,15 +167,15 @@
   "requiredItemIds": [
     {
       "itemId": "snitch_scanner",
-      "quantity": 1
+      "quantity": 2
     },
     {
       "itemId": "wasp_driver",
-      "quantity": 1
+      "quantity": 2
     },
     {
       "itemId": "hornet_driver",
-      "quantity": 1
+      "quantity": 2
     }
   ],
   "grantedItemIds": [


### PR DESCRIPTION
Old json incorrectly stated 1 of each driver was required. 2 are required of each