### PR TITLE
Fix wire recycling quantity in broken_handheld_radio.json

### DIFF
--- a/items/broken_handheld_radio.json
+++ b/items/broken_handheld_radio.json
@@ -25,7 +25,7 @@
   "value": 2000,
   "recyclesInto": {
     "sensors": 3,
-    "wires": 3
+    "wires": 2
   },
   "updatedAt": "12/07/2025",
   "description": {


### PR DESCRIPTION
Updated the recyclable wire quantity from 3 to 2.