### PR TITLE
Update recycling value for damaged_arc_powercell

### DIFF
--- a/items/damaged_arc_powercell.json
+++ b/items/damaged_arc_powercell.json
@@ -44,7 +44,7 @@
   "rarity": "Common",
   "value": 293,
   "recyclesInto": {
-    "arc_alloy": 2
+    "arc_alloy": 1
   },
   "salvagesInto": {
     "metal_parts": 1


### PR DESCRIPTION
Reduced the recycling value of 'damaged_arc_powercell' from 2 to 1 for 'arc_alloy'.