### PR TITLE
Update recycling options in tactical_mk2.json

### DIFF
--- a/items/tactical_mk2.json
+++ b/items/tactical_mk2.json
@@ -113,7 +113,7 @@
   "weightKg": 2,
   "recyclesInto": {
     "advanced_electrical_components": 1,
-    "processor": 1
+    "magnet": 1
   },
   "recipe": {
     "electrical_components": 2,


### PR DESCRIPTION
Replaced 'processor' with 'magnet' in recycling materials.