### PR TITLE
Fix Vita Shot recipe

### DIFF
--- a/items/vita_shot.json
+++ b/items/vita_shot.json
@@ -92,7 +92,7 @@
   },
   "imageFilename": "https://cdn.arctracker.io/items/vita_shot.png",
   "recipe": {
-    "antiseptic": 1,
+    "antiseptic": 2,
     "syringe": 1
   },
   "recyclesInto": {


### PR DESCRIPTION
<img width="724" height="1101" alt="image" src="https://github.com/user-attachments/assets/3855328a-dc16-40ad-bf92-0643aa4e183f" />

Vita Shot recipe now requires 2x Antiseptic, not just 1.