### PR TITLE
Update eyes_on_the_prize.json requiredItemIds

### DIFF
--- a/quests/eyes_on_the_prize.json
+++ b/quests/eyes_on_the_prize.json
@@ -89,7 +89,7 @@
   ],
   "requiredItemIds": [
     {
-      "itemId": "wire",
+      "itemId": "wires",
       "quantity": 3
     }
   ],


### PR DESCRIPTION
requiredItemIds[0].itemId was "wire" but should be "wires" to match item id in other quests and the item id in items dir