### PR TITLE
Amended trades.json to reflect Shani's new items and costs

### DIFF
--- a/trades.json
+++ b/trades.json
@@ -274,20 +274,200 @@
     "itemId": "binoculars",
     "quantity": 1,
     "cost": {
-      "itemId": "coins",
-      "quantity": 1920
+      "itemId": "creds",
+      "quantity": 20
     },
     "dailyLimit": null
+  },
+  {
+    "trader": "Shani",
+    "itemId": "blue_light_stick",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 10
+    },
+    "dailyLimit": null
+  },
+  {
+    "trader": "Shani",
+    "itemId": "firecracker",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 20
+    },
+    "dailyLimit": null
+  },
+  {
+    "trader": "Shani",
+    "itemId": "green_light_stick",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 10
+    },
+    "dailyLimit": null
+  },
+  {
+    "trader": "Shani",
+    "itemId": "red_light_stick",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 10
+    },
+    "dailyLimit": null
+  },
+  {
+    "trader": "Shani",
+    "itemId": "yellow_light_stick",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 10
+    },
+    "dailyLimit": null
+  },
+  {
+    "trader": "Shani",
+    "itemId": "combat_mk2",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "looting_mk2",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "tactical_mk2",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "angled_grip_ii",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "compensator_ii",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "extended_light_mag_ii",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "extended_medium_mag_ii",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "silencer_i",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 1
+  },
+  {
+    "trader": "Shani",
+    "itemId": "stable_stock_ii",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 100
+    },
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "recorder",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 50
+    },
+    "dailyLimit": 3
+  },
+  {
+    "trader": "Shani",
+    "itemId": "sterilized_bandage",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 40
+    },
+    "dailyLimit": 3
+  },
+  {
+    "trader": "Shani",
+    "itemId": "surge_shield_recharger",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 40
+    },
+    "dailyLimit": 5
   },
   {
     "trader": "Shani",
     "itemId": "raider_hatch_key",
     "quantity": 1,
     "cost": {
-      "itemId": "coins",
-      "quantity": 9000
+      "itemId": "creds",
+      "quantity": 100
     },
-    "dailyLimit": 1
+    "dailyLimit": 2
+  },
+  {
+    "trader": "Shani",
+    "itemId": "fireworks_box",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 60
+    },
+    "dailyLimit": 3
   },
   {
     "trader": "Tian Wen",


### PR DESCRIPTION
Add the new items that Shani is selling since December Update 1.7.0 and updated her prices to use creds in trades.json:

- Binoculars - 20 creds no limit
- Blue Light Stick - 10 creds no limit
- Firecracker - 20 creds no limit
- Green Light Stick - 10 creds no limit
- Red Light Stick - 10 creds no limit
- Yellow Light Stick - 10 creds no limit
- Combat Mk2 - 100 creds 2/2
- Looting Mk2 - 100 creds 2/2
- Tactical Mk2 - 100 creds 2/2
- Angled Grip 2 - 100 creds 2/2
- Compensator 2 - 100 creds 2/2
- Extended Light Mag 2 - 100 creds 2/2
- Extended Medium Mag 2 - 100 creds 2/2
- Silencer 1 - 100 creds 1/1
- Stable Stock 2  - 100 creds 2/2
- Recorder - 50 creds 3/3
- Sterilized Bandage  - 40 creds 3/3
- Surge Shield Recharger - 40 creds 5/5
- Radier Hatch Key - 100 creds 2/2
- Fireworks Box - 60 creds 3/3