### PR TITLE
Add the missing crafting recipes

### DIFF
--- a/items/blaze_grenade.json
+++ b/items/blaze_grenade.json
@@ -115,5 +115,11 @@
       "value": "10m"
     }
   },
-  "updatedAt": "10/30/2025"
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "explosive_compound": 1,
+    "oil": 2
+  },
+  "craftBench": "explosives_bench",
+  "stationLevelRequired": 3
 }

--- a/items/blue_light_stick.json
+++ b/items/blue_light_stick.json
@@ -90,7 +90,12 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/blue_light_stick.png",
-  "updatedAt": "11/01/2025",
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "chemicals": 3
+  },
+  "craftBench": "utility_bench",
+  "stationLevelRequired": 2,
   "recyclesInto": {
     "chemicals": 1
   }

--- a/items/extended_shotgun_mag_ii.json
+++ b/items/extended_shotgun_mag_ii.json
@@ -68,5 +68,11 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_shotgun_mag_ii.png",
-  "updatedAt": "11/02/2025"
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "mechanical_components": 2,
+    "steel_spring": 3
+  },
+  "craftBench": "weapon_bench",
+  "stationLevelRequired": 2
 }

--- a/items/flame_spray.json
+++ b/items/flame_spray.json
@@ -89,5 +89,10 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/flame_spray.png",
-  "updatedAt": "11/04/2025"
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "air_freshener": 1,
+    "fireball_burner": 1
+  },
+  "craftBench": "Inventory"
 }

--- a/items/noisemaker.json
+++ b/items/noisemaker.json
@@ -90,5 +90,10 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/noisemaker.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "speaker_component": 1,
+    "plastic_parts": 2
+  },
+  "craftBench": "Inventory"
 }

--- a/items/padded_stock.json
+++ b/items/padded_stock.json
@@ -173,5 +173,11 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/padded_stock.png",
-  "updatedAt": "11/12/2025"
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "mod_components": 2,
+    "duct_tape": 5
+  },
+  "craftBench": "weapon_bench",
+  "stationLevelRequired": 3
 }

--- a/items/pulse_mine.json
+++ b/items/pulse_mine.json
@@ -75,7 +75,12 @@
     "chemicals": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/pulse_mine.png",
-  "updatedAt": "12/16/2025",
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "crude_explosives": 1,
+    "wires": 1
+  },
   "craftBench": "explosives_bench",
+  "stationLevelRequired": 1,
   "blueprintLocked": true
 }

--- a/items/silencer_i.json
+++ b/items/silencer_i.json
@@ -41,7 +41,7 @@
     "sr": "Blago smanjuje količinu buke proizvedene pri pucanju."
   },
   "type": "Modification",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "12/31/2025",
   "rarity": "Uncommon",
   "effects": {
     "Noise Reduction": {
@@ -68,5 +68,11 @@
   },
   "value": 2000,
   "weightKg": 0.25,
-  "imageFilename": "https://cdn.arctracker.io/items/silencer_i.png"
+  "imageFilename": "https://cdn.arctracker.io/items/silencer_i.png",
+  "recipe": {
+    "mechanical_components": 2,
+    "wires": 4
+  },
+  "craftBench": "weapon_bench",
+  "stationLevelRequired": 2
 }

--- a/items/silencer_ii.json
+++ b/items/silencer_ii.json
@@ -68,5 +68,11 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/silencer_ii.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "mod_components": 2,
+    "wires": 8
+  },
+  "craftBench": "weapon_bench",
+  "stationLevelRequired": 3
 }

--- a/items/tactical_mk3_healing.json
+++ b/items/tactical_mk3_healing.json
@@ -114,5 +114,11 @@
   "weightKg": 4,
   "value": 5000,
   "imageFilename": "https://cdn.arctracker.io/items/tactical_mk3_healing.png",
-  "updatedAt": "11/05/2025"
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "advanced_electrical_components": 2,
+    "processor": 3
+  },
+  "craftBench": "equipment_bench",
+  "stationLevelRequired": 3
 }

--- a/items/yellow_light_stick.json
+++ b/items/yellow_light_stick.json
@@ -93,5 +93,10 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/yellow_light_stick.png",
-  "updatedAt": "11/01/2025"
+  "updatedAt": "12/31/2025",
+  "recipe": {
+    "chemicals": 3
+  },
+  "craftBench": "explosives_bench",
+  "stationLevelRequired": 3
 }


### PR DESCRIPTION
Added missing recipes, I think then we would have them all (hopefully?):

* Blue Light Stick: 3x Chemicals, Utility Station level 2
* Yellow Light Stick: 3x Chemicals, Explosives Station level 3
* Blaze Grenade: 1x Explosive Compound, 2x Oil, Explosives Station level 3
* Pulse Mine: 1x Crude Explosives, 1x Wires, Explosives Station level 1
* Padded Stock: 2x Mod Components, 5x Duct Tape, Gunsmith level 3
* Silencer I: 2x Mechanical Components, 4x Wires, Gunsmith level 2
* Silencer II: 2x Mod Components, 8x Wires, Gunsmith level 3
* Extended Shotgun Mag II: 2x Mechanical Components, 3x Steel Spring, Gunsmith level 2
* Tactical Mk. 3 (Healing): 2x Advanced Electrical Components, 3x Processor, Gear Bench level 3
* Flame Spray: 1x Air Freshener, 1x Fireball Burner (no station requirement)
* Noisemaker: 1x Speaker Component, 2x Plastic Parts (no station requirement)

The "Flame Spray" and "Noisemaker" can only be crafted in-round using the "Traveling Tinker" skill. Currently we have a
```
  "craftBench": "Inventory",
```
Maybe this could be further specified and split in the two of the potential skills that enable it: See https://www.reddit.com/r/ArcRaiders/comments/1p2l2ua/i_made_a_list_of_what_inround_crafting_and/ for a complete list for both skills.

Suggestions? `requiresInRoundCrafting` and `requiresTravelingTinkerer`?
Or:
```
   "craftBench": "Inventory",
   "requiresSkill": "traveling_tinkerer" (or surv_5c)
```
