### PR TITLE
Updated salvageInto and recycleInto for 220 items

### DIFF
--- a/items/acoustic_guitar.json
+++ b/items/acoustic_guitar.json
@@ -47,9 +47,15 @@
   "type": "Quick Use",
   "rarity": "Legendary",
   "value": 7000,
-  "recyclesInto": {},
+  "recyclesInto": {
+    "metal_parts": 4,
+    "wires": 6
+  },
   "weightKg": 1,
   "stackSize": 1,
   "imageFilename": "https://cdn.arctracker.io/items/acoustic_guitar.png",
-  "updatedAt": "12/17/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "wires": 3
+  }
 }

--- a/items/advanced_arc_powercell.json
+++ b/items/advanced_arc_powercell.json
@@ -54,5 +54,8 @@
   "weightKg": 0.5,
   "stackSize": 5,
   "foundIn": "ARC",
-  "updatedAt": "11/05/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "arc_powercell": 1
+  }
 }

--- a/items/advanced_mechanical_components.json
+++ b/items/advanced_mechanical_components.json
@@ -49,16 +49,19 @@
   "value": 1750,
   "recyclesInto": {
     "mechanical_components": 1,
-    "wires": 1
+    "steel_spring": 1
   },
   "weightKg": 1,
   "imageFilename": "https://cdn.arctracker.io/items/advanced_mechanical_components.png",
   "foundIn": "Mechanical",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "stackSize": 5,
   "recipe": {
     "steel_spring": 2,
     "mechanical_components": 2
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/agave.json
+++ b/items/agave.json
@@ -122,5 +122,11 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/agave.png",
-  "updatedAt": "11/05/2025"
+  "updatedAt": "01/09/2026",
+  "recyclesInto": {
+    "assorted_seeds": 3
+  },
+  "salvagesInto": {
+    "assorted_seeds": 2
+  }
 }

--- a/items/angled_grip_i.json
+++ b/items/angled_grip_i.json
@@ -74,10 +74,16 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/angled_grip_i.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "plastic_parts": 6,
     "duct_tape": 1
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "recyclesInto": {
+    "plastic_parts": 6
+  },
+  "salvagesInto": {
+    "plastic_parts": 3
+  }
 }

--- a/items/angled_grip_ii.json
+++ b/items/angled_grip_ii.json
@@ -92,5 +92,8 @@
     "Stitcher"
   ],
   "imageFilename": "https://cdn.arctracker.io/items/angled_grip_ii.png",
-  "updatedAt": "11/05/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/angled_grip_iii.json
+++ b/items/angled_grip_iii.json
@@ -97,7 +97,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/angled_grip_iii.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "duct_tape": 5
@@ -108,5 +108,8 @@
   "recyclesInto": {
     "mod_components": 1,
     "duct_tape": 2
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
   }
 }

--- a/items/antiseptic.json
+++ b/items/antiseptic.json
@@ -54,10 +54,13 @@
   "weightKg": 1,
   "stackSize": 5,
   "value": 1000,
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 10,
     "great_mullein": 2
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "chemicals": 5
+  }
 }

--- a/items/anvil_splitter.json
+++ b/items/anvil_splitter.json
@@ -100,6 +100,9 @@
     "mod_components": 1,
     "processor": 1
   },
-  "updatedAt": "11/01/2025",
-  "imageFilename": "https://cdn.arctracker.io/items/anvil_splitter.png"
+  "updatedAt": "01/09/2026",
+  "imageFilename": "https://cdn.arctracker.io/items/anvil_splitter.png",
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/apricot.json
+++ b/items/apricot.json
@@ -102,5 +102,8 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/apricot.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "assorted_seeds": 2
+  }
 }

--- a/items/arc_alloy.json
+++ b/items/arc_alloy.json
@@ -54,5 +54,8 @@
   "weightKg": 0.25,
   "stackSize": 15,
   "foundIn": "ARC",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "metal_parts": 1
+  }
 }

--- a/items/arc_circuitry.json
+++ b/items/arc_circuitry.json
@@ -54,9 +54,12 @@
   "weightKg": 0.3,
   "stackSize": 5,
   "foundIn": "ARC",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "arc_alloy": 8
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "arc_alloy": 1
+  }
 }

--- a/items/arc_motion_core.json
+++ b/items/arc_motion_core.json
@@ -54,9 +54,12 @@
   "stackSize": 5,
   "foundIn": "ARC",
   "imageFilename": "https://cdn.arctracker.io/items/arc_motion_core.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "arc_alloy": 8
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "arc_alloy": 1
+  }
 }

--- a/items/arc_synthetic_resin.json
+++ b/items/arc_synthetic_resin.json
@@ -31,7 +31,7 @@
     "plastic_parts": 14
   },
   "salvagesInto": {
-    "plastic_parts": 8
+    "plastic_parts": 9
   },
   "description": {
     "en": "Can be recycled into crafting materials.",
@@ -57,5 +57,5 @@
   },
   "foundIn": "ARC",
   "imageFilename": "https://cdn.arctracker.io/items/arc_synthetic_resin.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "01/09/2026"
 }

--- a/items/arpeggio_i.json
+++ b/items/arpeggio_i.json
@@ -47,7 +47,7 @@
   "type": "Assault Rifle",
   "rarity": "Uncommon",
   "imageFilename": "https://cdn.arctracker.io/items/arpeggio.png",
-  "updatedAt": "11/11/2025",
+  "updatedAt": "01/09/2026",
   "value": 5500,
   "weightKg": 7,
   "effects": {
@@ -172,5 +172,12 @@
     "simple_gun_parts": 6
   },
   "craftBench": "weapon_bench",
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "mechanical_components": 2,
+    "simple_gun_parts": 2
+  },
+  "salvagesInto": {
+    "simple_gun_parts": 2
+  }
 }

--- a/items/arpeggio_ii.json
+++ b/items/arpeggio_ii.json
@@ -47,7 +47,7 @@
   "type": "Assault Rifle",
   "rarity": "Uncommon",
   "imageFilename": "https://cdn.arctracker.io/items/arpeggio.png",
-  "updatedAt": "11/11/2025",
+  "updatedAt": "01/09/2026",
   "value": 8000,
   "weightKg": 7,
   "effects": {
@@ -218,5 +218,12 @@
     "mechanical_components": 4,
     "simple_gun_parts": 1
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "mechanical_components": 3,
+    "simple_gun_parts": 3
+  },
+  "salvagesInto": {
+    "simple_gun_parts": 3
+  }
 }

--- a/items/arpeggio_iii.json
+++ b/items/arpeggio_iii.json
@@ -47,7 +47,7 @@
   "type": "Assault Rifle",
   "rarity": "Uncommon",
   "imageFilename": "https://cdn.arctracker.io/items/arpeggio.png",
-  "updatedAt": "11/11/2025",
+  "updatedAt": "01/09/2026",
   "value": 11500,
   "weightKg": 7,
   "effects": {
@@ -218,5 +218,12 @@
     "mechanical_components": 5,
     "medium_gun_parts": 1
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "mechanical_components": 4,
+    "simple_gun_parts": 4
+  },
+  "salvagesInto": {
+    "simple_gun_parts": 4
+  }
 }

--- a/items/arpeggio_iv.json
+++ b/items/arpeggio_iv.json
@@ -47,7 +47,7 @@
   "type": "Assault Rifle",
   "rarity": "Uncommon",
   "imageFilename": "https://cdn.arctracker.io/items/arpeggio.png",
-  "updatedAt": "11/11/2025",
+  "updatedAt": "01/09/2026",
   "value": 15000,
   "weightKg": 7,
   "effects": {
@@ -222,5 +222,8 @@
     "mechanical_components": 5,
     "simple_gun_parts": 5
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 5
+  }
 }

--- a/items/bandage.json
+++ b/items/bandage.json
@@ -123,7 +123,7 @@
       "he": "זמן שימוש"
     }
   },
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "imageFilename": "https://cdn.arctracker.io/items/bandage.png",
   "recipe": {
     "fabric": 5
@@ -131,5 +131,8 @@
   "craftBench": [
     "workbench",
     "med_station"
-  ]
+  ],
+  "salvagesInto": {
+    "fabric": 1
+  }
 }

--- a/items/barricade_kit.json
+++ b/items/barricade_kit.json
@@ -101,10 +101,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/barricade_kit.png",
-  "updatedAt": "11/13/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 1
   },
   "craftBench": "utility_bench",
-  "stationLevelRequired": 1
+  "stationLevelRequired": 1,
+  "salvagesInto": {
+    "metal_parts": 3
+  }
 }

--- a/items/bettina_i.json
+++ b/items/bettina_i.json
@@ -166,12 +166,19 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/bettina.png",
-  "updatedAt": "11/09/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "advanced_mechanical_components": 3,
     "heavy_gun_parts": 3,
     "canister": 3
   },
   "craftBench": "weapon_bench",
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "advanced_mechanical_components": 1,
+    "heavy_gun_parts": 2
+  },
+  "salvagesInto": {
+    "advanced_mechanical_components": 1
+  }
 }

--- a/items/bettina_ii.json
+++ b/items/bettina_ii.json
@@ -212,11 +212,18 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/bettina.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "craftBench": "weapon_bench",
   "upgradeCost": {
     "advanced_mechanical_components": 1,
     "heavy_gun_parts": 2
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "advanced_mechanical_components": 2,
+    "heavy_gun_parts": 2
+  },
+  "salvagesInto": {
+    "advanced_mechanical_components": 2
+  }
 }

--- a/items/bettina_iii.json
+++ b/items/bettina_iii.json
@@ -212,11 +212,18 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/bettina.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "craftBench": "weapon_bench",
   "upgradeCost": {
     "advanced_mechanical_components": 1,
     "heavy_gun_parts": 2
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "advanced_mechanical_components": 2,
+    "heavy_gun_parts": 3
+  },
+  "salvagesInto": {
+    "advanced_mechanical_components": 3
+  }
 }

--- a/items/bettina_iv.json
+++ b/items/bettina_iv.json
@@ -212,11 +212,18 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/bettina.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "craftBench": "weapon_bench",
   "upgradeCost": {
     "advanced_mechanical_components": 2,
     "heavy_gun_parts": 2
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "advanced_mechanical_components": 3,
+    "heavy_gun_parts": 3
+  },
+  "salvagesInto": {
+    "advanced_mechanical_components": 4
+  }
 }

--- a/items/binoculars.json
+++ b/items/binoculars.json
@@ -45,7 +45,7 @@
     "he": "משקפת בסיסית עם שתי רמות הגדלה."
   },
   "type": "Quick Use",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "rarity": "Common",
   "value": 640,
   "recyclesInto": {
@@ -83,5 +83,8 @@
     "plastic_parts": 8,
     "rubber_parts": 4
   },
-  "craftBench": "utility_bench"
+  "craftBench": "utility_bench",
+  "salvagesInto": {
+    "plastic_parts": 4
+  }
 }

--- a/items/blaze_grenade.json
+++ b/items/blaze_grenade.json
@@ -125,11 +125,14 @@
       "he": "רדיוס"
     }
   },
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "explosive_compound": 1,
     "oil": 2
   },
   "craftBench": "explosives_bench",
-  "stationLevelRequired": 3
+  "stationLevelRequired": 3,
+  "salvagesInto": {
+    "oil": 1
+  }
 }

--- a/items/blue_light_stick.json
+++ b/items/blue_light_stick.json
@@ -98,13 +98,16 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/blue_light_stick.png",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 3
   },
   "craftBench": "utility_bench",
   "stationLevelRequired": 2,
   "recyclesInto": {
+    "chemicals": 1
+  },
+  "salvagesInto": {
     "chemicals": 1
   }
 }

--- a/items/broken_handheld_radio.json
+++ b/items/broken_handheld_radio.json
@@ -29,7 +29,7 @@
     "sensors": 3,
     "wires": 2
   },
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "Can be recycled into crafting materials.",
     "de": "Kann zu Herstellungsmaterialien recycelt werden.",
@@ -55,5 +55,8 @@
   "weightKg": 3,
   "stackSize": 3,
   "foundIn": "Security",
-  "imageFilename": "https://cdn.arctracker.io/items/broken_handheld_radio.png"
+  "imageFilename": "https://cdn.arctracker.io/items/broken_handheld_radio.png",
+  "salvagesInto": {
+    "sensors": 2
+  }
 }

--- a/items/broken_taser.json
+++ b/items/broken_taser.json
@@ -54,6 +54,9 @@
   "weightKg": 2,
   "stackSize": 3,
   "foundIn": "Security",
-  "updatedAt": "11/11/2025",
-  "imageFilename": "https://cdn.arctracker.io/items/broken_taser.png"
+  "updatedAt": "01/09/2026",
+  "imageFilename": "https://cdn.arctracker.io/items/broken_taser.png",
+  "salvagesInto": {
+    "battery": 2
+  }
 }

--- a/items/burletta_i.json
+++ b/items/burletta_i.json
@@ -53,7 +53,7 @@
     "simple_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 4,
   "effects": {
     "Durability": {
@@ -177,5 +177,8 @@
     "simple_gun_parts": 3
   },
   "craftBench": "weapon_bench",
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 2
+  }
 }

--- a/items/burletta_ii.json
+++ b/items/burletta_ii.json
@@ -57,6 +57,9 @@
     "simple_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "11/24/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 2
+  }
 }

--- a/items/burletta_iii.json
+++ b/items/burletta_iii.json
@@ -57,6 +57,9 @@
     "simple_gun_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "11/24/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 3
+  }
 }

--- a/items/burletta_iv.json
+++ b/items/burletta_iv.json
@@ -57,6 +57,9 @@
     "simple_gun_parts": 4
   },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "11/24/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 3
+  }
 }

--- a/items/canister.json
+++ b/items/canister.json
@@ -54,5 +54,8 @@
   "weightKg": 0.25,
   "stackSize": 15,
   "foundIn": "Commercial",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "plastic_parts": 1
+  }
 }

--- a/items/combat_mk1.json
+++ b/items/combat_mk1.json
@@ -52,7 +52,7 @@
     "rubber_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/combat_i.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 2,
   "effects": {
     "Durability": {
@@ -129,5 +129,8 @@
     "plastic_parts": 6,
     "rubber_parts": 6
   },
-  "craftBench": "equipment_bench"
+  "craftBench": "equipment_bench",
+  "salvagesInto": {
+    "plastic_parts": 3
+  }
 }

--- a/items/combat_mk2.json
+++ b/items/combat_mk2.json
@@ -48,7 +48,7 @@
   "rarity": "Rare",
   "value": 2000,
   "imageFilename": "https://cdn.arctracker.io/items/combat_i.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 3,
   "effects": {
     "Restores": {
@@ -152,5 +152,8 @@
     "electrical_components": 2,
     "magnet": 3
   },
-  "craftBench": "equipment_bench"
+  "craftBench": "equipment_bench",
+  "salvagesInto": {
+    "electrical_components": 1
+  }
 }

--- a/items/combat_mk3_aggressive.json
+++ b/items/combat_mk3_aggressive.json
@@ -251,5 +251,8 @@
     "processor": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/combat_mk3_aggressive.png",
-  "updatedAt": "11/13/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "electrical_components": 2
+  }
 }

--- a/items/combat_mk3_flanking.json
+++ b/items/combat_mk3_flanking.json
@@ -251,5 +251,8 @@
     "processor": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/combat_mk3_flanking.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "electrical_components": 2
+  }
 }

--- a/items/compensator_ii.json
+++ b/items/compensator_ii.json
@@ -108,10 +108,13 @@
     "Stitcher"
   ],
   "imageFilename": "https://cdn.arctracker.io/items/compensator_ii.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 2,
     "wires": 4
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/compensator_iii.json
+++ b/items/compensator_iii.json
@@ -120,8 +120,8 @@
     }
   },
   "recyclesInto": {
-    "mechanical_components": 1,
-    "wires": 2
+    "wires": 2,
+    "mod_components": 1
   },
   "compatibleWith": [
     "Ferro",
@@ -140,12 +140,15 @@
     "Tempest"
   ],
   "imageFilename": "https://cdn.arctracker.io/items/compensator_ii.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "wires": 8
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/complex_gun_parts.json
+++ b/items/complex_gun_parts.json
@@ -54,11 +54,14 @@
   "recyclesInto": {
     "simple_gun_parts": 3
   },
-  "updatedAt": "11/21/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "light_gun_parts": 2,
     "medium_gun_parts": 2,
     "heavy_gun_parts": 2
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "simple_gun_parts": 2
+  }
 }

--- a/items/cooling_coil.json
+++ b/items/cooling_coil.json
@@ -55,5 +55,8 @@
   "stackSize": 3,
   "foundIn": "Industrial",
   "imageFilename": "https://cdn.arctracker.io/items/cooling_coil.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "steel_spring": 2
+  }
 }

--- a/items/cooling_fan.json
+++ b/items/cooling_fan.json
@@ -55,5 +55,8 @@
   "stackSize": 3,
   "foundIn": "Technological",
   "imageFilename": "https://cdn.arctracker.io/items/cooling_fan.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "wires": 4
+  }
 }

--- a/items/cracked_bioscanner.json
+++ b/items/cracked_bioscanner.json
@@ -55,5 +55,8 @@
   },
   "foundIn": "Medical",
   "imageFilename": "https://cdn.arctracker.io/items/cracked_bioscanner.png",
-  "updatedAt": "11/14/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "battery": 2
+  }
 }

--- a/items/damaged_arc_motion_core.json
+++ b/items/damaged_arc_motion_core.json
@@ -51,11 +51,11 @@
   "value": 640,
   "foundIn": "ARC",
   "imageFilename": "https://cdn.arctracker.io/items/damaged_arc_motion_core.png",
-  "updatedAt": "11/07/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
-    "arc_alloy": 2
+    "arc_alloy": 3
   },
   "salvagesInto": {
-    "arc_alloy": 1
+    "arc_alloy": 2
   }
 }

--- a/items/damaged_fireball_burner.json
+++ b/items/damaged_fireball_burner.json
@@ -54,5 +54,8 @@
   "stackSize": 3,
   "foundIn": "ARC",
   "imageFilename": "https://cdn.arctracker.io/items/damaged_fireball_burner.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "metal_parts": 1
+  }
 }

--- a/items/damaged_rocketeer_driver.json
+++ b/items/damaged_rocketeer_driver.json
@@ -53,6 +53,9 @@
   "weightKg": 0.25,
   "stackSize": 3,
   "foundIn": "ARC",
-  "updatedAt": "11/03/2025",
-  "imageFilename": "https://cdn.arctracker.io/items/damaged_rocketeer_driver.png"
+  "updatedAt": "01/09/2026",
+  "imageFilename": "https://cdn.arctracker.io/items/damaged_rocketeer_driver.png",
+  "salvagesInto": {
+    "arc_alloy": 2
+  }
 }

--- a/items/deadline.json
+++ b/items/deadline.json
@@ -121,7 +121,8 @@
     }
   },
   "recyclesInto": {
-    "explosive_compound": 1
+    "explosive_compound": 1,
+    "arc_circuitry": 1
   },
   "craftBench": "explosives_bench",
   "recipe": {
@@ -129,5 +130,8 @@
     "arc_circuitry": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/deadline.png",
-  "updatedAt": "11/21/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "explosive_compound": 1
+  }
 }

--- a/items/defibrillator.json
+++ b/items/defibrillator.json
@@ -107,5 +107,8 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/defibrillator.png",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "chemicals": 2
+  }
 }

--- a/items/deflated_football.json
+++ b/items/deflated_football.json
@@ -46,7 +46,8 @@
   },
   "type": "Recyclable",
   "recyclesInto": {
-    "rubber_parts": 15
+    "rubber_parts": 9,
+    "fabric": 9
   },
   "salvagesInto": {
     "rubber_parts": 9
@@ -57,5 +58,5 @@
   "weightKg": 0.8,
   "stackSize": 3,
   "foundIn": "Residential",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "01/09/2026"
 }

--- a/items/diving_goggles.json
+++ b/items/diving_goggles.json
@@ -54,5 +54,8 @@
   "stackSize": 3,
   "foundIn": "Residential",
   "imageFilename": "https://cdn.arctracker.io/items/diving_goggles.png",
-  "updatedAt": "11/23/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "rubber_parts": 5
+  }
 }

--- a/items/door_blocker.json
+++ b/items/door_blocker.json
@@ -50,7 +50,7 @@
   "weightKg": 0.2,
   "stackSize": 3,
   "imageFilename": "https://cdn.arctracker.io/items/door_blocker.png",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "metal_parts": 2
   },
@@ -58,5 +58,8 @@
     "metal_parts": 3,
     "rubber_parts": 3
   },
-  "craftBench": "utility_bench"
+  "craftBench": "utility_bench",
+  "salvagesInto": {
+    "metal_parts": 1
+  }
 }

--- a/items/dried_out_arc_resin.json
+++ b/items/dried_out_arc_resin.json
@@ -54,5 +54,8 @@
   },
   "foundIn": "ARC",
   "imageFilename": "https://cdn.arctracker.io/items/dried_out_arc_resin.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "plastic_parts": 4
+  }
 }

--- a/items/duct_tape.json
+++ b/items/duct_tape.json
@@ -54,5 +54,8 @@
   "weightKg": 0.25,
   "stackSize": 15,
   "foundIn": "Residential, Commercial",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "fabric": 1
+  }
 }

--- a/items/durable_cloth.json
+++ b/items/durable_cloth.json
@@ -50,7 +50,7 @@
   "stackSize": 10,
   "weightKg": 0.25,
   "imageFilename": "https://cdn.arctracker.io/items/durable_cloth.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "value": 640,
   "recyclesInto": {
     "fabric": 6
@@ -58,5 +58,8 @@
   "recipe": {
     "fabric": 14
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "fabric": 2
+  }
 }

--- a/items/explosive_mine.json
+++ b/items/explosive_mine.json
@@ -50,8 +50,8 @@
   "weightKg": 0.5,
   "stackSize": 3,
   "recyclesInto": {
-    "chemicals": 1,
-    "sensors": 1
+    "sensors": 1,
+    "oil": 2
   },
   "recipe": {
     "explosive_compound": 1,
@@ -109,5 +109,8 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/explosive_mine.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "oil": 2
+  }
 }

--- a/items/extended_barrel.json
+++ b/items/extended_barrel.json
@@ -97,7 +97,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_barrel.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "wires": 8
@@ -108,5 +108,8 @@
   "recyclesInto": {
     "mod_components": 1,
     "wires": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
   }
 }

--- a/items/extended_light_mag_ii.json
+++ b/items/extended_light_mag_ii.json
@@ -78,12 +78,15 @@
     "mechanical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_light_mag_ii.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 2,
     "steel_spring": 3
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 2,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/extended_light_mag_iii.json
+++ b/items/extended_light_mag_iii.json
@@ -74,7 +74,7 @@
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_light_mag_iii.png",
   "value": 5000,
-  "updatedAt": "10/30/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "mod_components": 1,
     "steel_spring": 2
@@ -85,5 +85,8 @@
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/extended_medium_mag_i.json
+++ b/items/extended_medium_mag_i.json
@@ -74,10 +74,16 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_medium_mag_i.png",
-  "updatedAt": "11/22/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "plastic_parts": 6,
     "steel_spring": 1
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "recyclesInto": {
+    "plastic_parts": 6
+  },
+  "salvagesInto": {
+    "plastic_parts": 3
+  }
 }

--- a/items/extended_medium_mag_ii.json
+++ b/items/extended_medium_mag_ii.json
@@ -74,10 +74,17 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_medium_mag_ii.png",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 2,
     "steel_spring": 3
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "recyclesInto": {
+    "mechanical_components": 1,
+    "steel_spring": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/extended_medium_mag_iii.json
+++ b/items/extended_medium_mag_iii.json
@@ -74,7 +74,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_medium_mag_iii.png",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "mod_components": 1,
     "steel_spring": 2
@@ -83,5 +83,8 @@
     "mod_components": 2,
     "steel_spring": 5
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/extended_shotgun_mag_i.json
+++ b/items/extended_shotgun_mag_i.json
@@ -74,7 +74,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_shotgun_mag_i.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "plastic_parts": 6,
     "steel_spring": 1
@@ -82,5 +82,8 @@
   "recyclesInto": {
     "plastic_parts": 6
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "salvagesInto": {
+    "plastic_parts": 3
+  }
 }

--- a/items/extended_shotgun_mag_ii.json
+++ b/items/extended_shotgun_mag_ii.json
@@ -74,11 +74,18 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_shotgun_mag_ii.png",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 2,
     "steel_spring": 3
   },
   "craftBench": "weapon_bench",
-  "stationLevelRequired": 2
+  "stationLevelRequired": 2,
+  "recyclesInto": {
+    "mechanical_components": 1,
+    "steel_spring": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/extended_shotgun_mag_iii.json
+++ b/items/extended_shotgun_mag_iii.json
@@ -78,5 +78,12 @@
     "steel_spring": 5
   },
   "imageFilename": "https://cdn.arctracker.io/items/extended_shotgun_mag_iii.png",
-  "updatedAt": "11/11/2025"
+  "updatedAt": "01/09/2026",
+  "recyclesInto": {
+    "mod_components": 1,
+    "steel_spring": 2
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/ferro_ii.json
+++ b/items/ferro_ii.json
@@ -173,6 +173,9 @@
     "rubber_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "11/24/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "metal_parts": 2
+  }
 }

--- a/items/ferro_iii.json
+++ b/items/ferro_iii.json
@@ -189,7 +189,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "11/24/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "metal_parts": 6,
     "simple_gun_parts": 1
@@ -198,5 +198,8 @@
     "metal_parts": 9,
     "simple_gun_parts": 1
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 1
+  }
 }

--- a/items/ferro_iv.json
+++ b/items/ferro_iv.json
@@ -57,14 +57,14 @@
     "materials": null
   },
   "salvagesInto": {
-    "metal_parts": 2
+    "simple_gun_parts": 2
   },
   "upgradeCost": {
     "mechanical_components": 1,
     "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "11/24/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 8,
   "effects": {
     "Durability": {

--- a/items/fertilizer.json
+++ b/items/fertilizer.json
@@ -53,6 +53,9 @@
   "weightKg": 0.4,
   "stackSize": 5,
   "foundIn": "Nature",
-  "updatedAt": "11/04/2025",
-  "imageFilename": "https://cdn.arctracker.io/items/fertilizer.png"
+  "updatedAt": "01/09/2026",
+  "imageFilename": "https://cdn.arctracker.io/items/fertilizer.png",
+  "salvagesInto": {
+    "assorted_seeds": 1
+  }
 }

--- a/items/fireball_burner.json
+++ b/items/fireball_burner.json
@@ -126,5 +126,8 @@
       "he": "רדיוס"
     }
   },
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "arc_alloy": 1
+  }
 }

--- a/items/flame_spray.json
+++ b/items/flame_spray.json
@@ -97,10 +97,17 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/flame_spray.png",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "air_freshener": 1,
     "fireball_burner": 1
   },
-  "craftBench": "in_raid"
+  "craftBench": "in_raid",
+  "recyclesInto": {
+    "canister": 1,
+    "fireball_burner": 1
+  },
+  "salvagesInto": {
+    "fireball_burner": 1
+  }
 }

--- a/items/flow_controller.json
+++ b/items/flow_controller.json
@@ -51,9 +51,12 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/flow_controller.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "advanced_mechanical_components": 1,
     "sensors": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
   }
 }

--- a/items/fossilized_lightning.json
+++ b/items/fossilized_lightning.json
@@ -54,5 +54,8 @@
   "recyclesInto": {
     "explosive_compound": 3
   },
-  "updatedAt": "12/16/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "explosive_compound": 2
+  }
 }

--- a/items/frequency_modulation_box.json
+++ b/items/frequency_modulation_box.json
@@ -49,11 +49,14 @@
   "weightKg": 1.5,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/frequency_modulation_box.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "value": 3000,
   "stackSize": 3,
   "recyclesInto": {
     "advanced_electrical_components": 1,
     "speaker_component": 1
+  },
+  "salvagesInto": {
+    "electrical_components": 2
   }
 }

--- a/items/gas_grenade.json
+++ b/items/gas_grenade.json
@@ -125,10 +125,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/gas_grenade.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 4,
     "rubber_parts": 2
   },
-  "craftBench": "explosives_bench"
+  "craftBench": "explosives_bench",
+  "salvagesInto": {
+    "chemicals": 1
+  }
 }

--- a/items/gas_mine.json
+++ b/items/gas_mine.json
@@ -132,5 +132,8 @@
   "stationLevelRequired": 1,
   "blueprintLocked": true,
   "imageFilename": "https://cdn.arctracker.io/items/gas_mine.png",
-  "updatedAt": "12/25/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "chemicals": 2
+  }
 }

--- a/items/geiger_counter.json
+++ b/items/geiger_counter.json
@@ -51,9 +51,12 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/geiger_counter.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "battery": 3,
     "exodus_modules": 1
+  },
+  "salvagesInto": {
+    "battery": 3
   }
 }

--- a/items/great_mullein.json
+++ b/items/great_mullein.json
@@ -28,7 +28,7 @@
   "recyclesInto": {
     "assorted_seeds": 2
   },
-  "updatedAt": "10/31/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "Used to craft medical supplies. Used to craft: Herbal Bandage, Antiseptic",
     "de": "Wird zur Herstellung medizinischer Objekte verwendet. Zur Herstellung von: Kräuterverband, Desinfektionsmittel",
@@ -54,5 +54,8 @@
   "weightKg": 0.25,
   "foundIn": "Nature",
   "stackSize": 15,
-  "imageFilename": "https://cdn.arctracker.io/items/great_mullein.png"
+  "imageFilename": "https://cdn.arctracker.io/items/great_mullein.png",
+  "salvagesInto": {
+    "assorted_seeds": 1
+  }
 }

--- a/items/green_light_stick.json
+++ b/items/green_light_stick.json
@@ -98,9 +98,15 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/green_light_stick.png",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 3
   },
-  "craftBench": "utility_bench"
+  "craftBench": "utility_bench",
+  "recyclesInto": {
+    "chemicals": 1
+  },
+  "salvagesInto": {
+    "chemicals": 1
+  }
 }

--- a/items/hairpin_ii.json
+++ b/items/hairpin_ii.json
@@ -235,10 +235,10 @@
   "weightKg": 3,
   "value": 1000,
   "imageFilename": "https://cdn.arctracker.io/items/hairpin_i.png",
-  "updatedAt": "11/11/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "metal_parts": 4,
-    "plastic_parts": 4
+    "rubber_parts": 3
   },
   "salvagesInto": {
     "metal_parts": 4

--- a/items/headphones.json
+++ b/items/headphones.json
@@ -55,5 +55,8 @@
   "stackSize": 3,
   "foundIn": "Residential, Commercial",
   "imageFilename": "https://cdn.arctracker.io/items/headphones.png",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "speaker_component": 1
+  }
 }

--- a/items/heavy_fuze_grenade.json
+++ b/items/heavy_fuze_grenade.json
@@ -98,7 +98,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/heavy_fuze_grenade.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "oil": 1,
     "rubber_parts": 2
@@ -107,5 +107,8 @@
     "explosive_compound": 1,
     "canister": 2
   },
-  "craftBench": "explosives_bench"
+  "craftBench": "explosives_bench",
+  "salvagesInto": {
+    "crude_explosives": 1
+  }
 }

--- a/items/heavy_gun_parts.json
+++ b/items/heavy_gun_parts.json
@@ -54,9 +54,12 @@
   "weightKg": 0.5,
   "stackSize": 5,
   "foundIn": "Security, Raider",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "simple_gun_parts": 4
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "simple_gun_parts": 1
+  }
 }

--- a/items/heavy_shield.json
+++ b/items/heavy_shield.json
@@ -147,10 +147,17 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/heavy_shield.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "power_rod": 1,
     "voltage_converter": 2
   },
-  "craftBench": "equipment_bench"
+  "craftBench": "equipment_bench",
+  "recyclesInto": {
+    "arc_circuitry": 2,
+    "voltage_converter": 1
+  },
+  "salvagesInto": {
+    "arc_alloy": 4
+  }
 }

--- a/items/herbal_bandage.json
+++ b/items/herbal_bandage.json
@@ -121,7 +121,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/herbal_bandage.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "durable_cloth": 1,
     "great_mullein": 1
@@ -130,5 +130,8 @@
   "recyclesInto": {
     "assorted_seeds": 2,
     "fabric": 5
+  },
+  "salvagesInto": {
+    "fabric": 8
   }
 }

--- a/items/household_cleaner.json
+++ b/items/household_cleaner.json
@@ -54,5 +54,8 @@
   "stackSize": 3,
   "foundIn": "Residential",
   "imageFilename": "https://cdn.arctracker.io/items/household_cleaner.png",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "chemicals": 5
+  }
 }

--- a/items/hullcracker_i.json
+++ b/items/hullcracker_i.json
@@ -171,7 +171,7 @@
     "heavy_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/hullcracker.png",
-  "updatedAt": "11/12/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "magnetic_accelerator": 1,
     "heavy_gun_parts": 3,
@@ -179,5 +179,8 @@
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "heavy_gun_parts": 2
+  }
 }

--- a/items/hullcracker_iv.json
+++ b/items/hullcracker_iv.json
@@ -205,6 +205,9 @@
   "stealth": 1,
   "weightKg": 7,
   "imageFilename": "https://cdn.arctracker.io/items/hullcracker.png",
-  "updatedAt": "11/12/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "heavy_gun_parts": 5
+  }
 }

--- a/items/humidifier.json
+++ b/items/humidifier.json
@@ -55,5 +55,8 @@
   "weightKg": 2,
   "stackSize": 3,
   "imageFilename": "https://cdn.arctracker.io/items/humidifier.png",
-  "updatedAt": "12/01/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "canister": 2
+  }
 }

--- a/items/il_toro_i.json
+++ b/items/il_toro_i.json
@@ -170,12 +170,15 @@
     "simple_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/il_toro.png",
-  "updatedAt": "11/12/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 5,
     "simple_gun_parts": 6
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 1,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 2
+  }
 }

--- a/items/il_toro_ii.json
+++ b/items/il_toro_ii.json
@@ -189,12 +189,19 @@
   "weightKg": 8,
   "value": 7000,
   "imageFilename": "https://cdn.arctracker.io/items/il_toro.png",
-  "updatedAt": "11/12/2025",
+  "updatedAt": "01/09/2026",
   "craftBench": "weapon_bench",
   "upgradeCost": {
     "mechanical_components": 3,
     "simple_gun_parts": 1
   },
   "stationLevelRequired": 1,
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "mechanical_components": 3,
+    "simple_gun_parts": 3
+  },
+  "salvagesInto": {
+    "simple_gun_parts": 3
+  }
 }

--- a/items/il_toro_iii.json
+++ b/items/il_toro_iii.json
@@ -205,6 +205,9 @@
   "stealth": 18,
   "weightKg": 8,
   "imageFilename": "https://cdn.arctracker.io/items/il_toro.png",
-  "updatedAt": "11/12/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 4
+  }
 }

--- a/items/il_toro_iv.json
+++ b/items/il_toro_iv.json
@@ -205,6 +205,9 @@
   "stealth": 18,
   "weightKg": 8,
   "imageFilename": "https://cdn.arctracker.io/items/il_toro.png",
-  "updatedAt": "11/12/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "simple_gun_parts": 5
+  }
 }

--- a/items/impure_arc_coolant.json
+++ b/items/impure_arc_coolant.json
@@ -54,5 +54,8 @@
   "weightKg": 0.33,
   "stackSize": 3,
   "imageFilename": "https://cdn.arctracker.io/items/impure_arc_coolant.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "chemicals": 5
+  }
 }

--- a/items/ion_sputter.json
+++ b/items/ion_sputter.json
@@ -50,10 +50,13 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/ion_sputter.png",
-  "updatedAt": "11/24/2025",
+  "updatedAt": "01/09/2026",
   "value": 6000,
   "recyclesInto": {
     "voltage_converter": 4,
+    "exodus_modules": 1
+  },
+  "salvagesInto": {
     "exodus_modules": 1
   }
 }

--- a/items/jolt_mine.json
+++ b/items/jolt_mine.json
@@ -120,7 +120,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/jolt_mine.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "battery": 1,
     "plastic_parts": 2
@@ -130,5 +130,8 @@
     "electrical_components": 1,
     "battery": 1
   },
-  "craftBench": "explosives_bench"
+  "craftBench": "explosives_bench",
+  "salvagesInto": {
+    "battery": 1
+  }
 }

--- a/items/kettle_i.json
+++ b/items/kettle_i.json
@@ -48,11 +48,11 @@
   "rarity": "Common",
   "value": 840,
   "recyclesInto": {
-    "plastic_parts": 3,
-    "rubber_parts": 2
+    "rubber_parts": 2,
+    "metal_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/kettle.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "metal_parts": 6,
     "rubber_parts": 8
@@ -179,5 +179,8 @@
       "he": "חדירת שריון ARC"
     }
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "metal_parts": 3
+  }
 }

--- a/items/kettle_ii.json
+++ b/items/kettle_ii.json
@@ -49,10 +49,13 @@
   "value": 840,
   "weightKg": 7,
   "recyclesInto": {
-    "plastic_parts": 6,
-    "rubber_parts": 6
+    "rubber_parts": 6,
+    "metal_parts": 6
   },
   "imageFilename": "https://cdn.arctracker.io/items/kettle.png",
-  "updatedAt": "10/30/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "metal_parts": 6
+  }
 }

--- a/items/kettle_iii.json
+++ b/items/kettle_iii.json
@@ -192,6 +192,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/kettle.png",
-  "updatedAt": "10/31/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "recyclesInto": {
+    "metal_parts": 12,
+    "simple_gun_parts": 1
+  },
+  "salvagesInto": {
+    "simple_gun_parts": 1
+  }
 }

--- a/items/kettle_iv.json
+++ b/items/kettle_iv.json
@@ -166,6 +166,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/kettle.png",
-  "updatedAt": "10/31/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "recyclesInto": {
+    "mechanical_components": 2,
+    "simple_gun_parts": 2
+  },
+  "salvagesInto": {
+    "simple_gun_parts": 2
+  }
 }

--- a/items/kinetic_converter.json
+++ b/items/kinetic_converter.json
@@ -124,5 +124,8 @@
     "mod_components": 1,
     "duct_tape": 2
   },
-  "updatedAt": "10/30/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/laboratory_reagents.json
+++ b/items/laboratory_reagents.json
@@ -49,10 +49,13 @@
   "value": 2000,
   "weightKg": 3,
   "recyclesInto": {
-    "chemicals": 2,
-    "crude_explosives": 2
+    "chemicals": 16,
+    "crude_explosives": 3
   },
   "foundIn": "Medical",
   "imageFilename": "https://cdn.arctracker.io/items/laboratory_reagents.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "crude_explosives": 3
+  }
 }

--- a/items/leaper_pulse_unit.json
+++ b/items/leaper_pulse_unit.json
@@ -77,7 +77,7 @@
       "he": "רדיוס"
     }
   },
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "Can be recycled into crafting materials. Can be thrown to create a violent singularity.",
     "de": "Kann zu Herstellungsmaterialien recycelt werden. Kann geworfen werden, um eine brutale Singularität zu erzeugen.",
@@ -103,5 +103,8 @@
   "weightKg": 1,
   "stackSize": 3,
   "foundIn": "ARC",
-  "imageFilename": "https://cdn.arctracker.io/items/leaper_pulse_unit.png"
+  "imageFilename": "https://cdn.arctracker.io/items/leaper_pulse_unit.png",
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/lemon.json
+++ b/items/lemon.json
@@ -102,5 +102,8 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/lemon.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "assorted_seeds": 2
+  }
 }

--- a/items/light_gun_parts.json
+++ b/items/light_gun_parts.json
@@ -54,9 +54,12 @@
   "weightKg": 0.3,
   "stackSize": 5,
   "imageFilename": "https://cdn.arctracker.io/items/light_gun_parts.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "simple_gun_parts": 4
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "simple_gun_parts": 1
+  }
 }

--- a/items/light_shield.json
+++ b/items/light_shield.json
@@ -127,7 +127,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/light_shield.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "arc_alloy": 2,
     "plastic_parts": 4
@@ -135,5 +135,8 @@
   "craftBench": [
     "workbench",
     "equipment_bench"
-  ]
+  ],
+  "salvagesInto": {
+    "arc_alloy": 1
+  }
 }

--- a/items/lightweight_stock.json
+++ b/items/lightweight_stock.json
@@ -166,10 +166,17 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/lightweight_stock.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "duct_tape": 5
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "recyclesInto": {
+    "duct_tape": 1,
+    "mod_components": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/lil_smoke_grenade.json
+++ b/items/lil_smoke_grenade.json
@@ -102,10 +102,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/lil_smoke_grenade.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 5,
     "plastic_parts": 1
   },
-  "craftBench": "utility_bench"
+  "craftBench": "utility_bench",
+  "salvagesInto": {
+    "chemicals": 2
+  }
 }

--- a/items/looting_mk1.json
+++ b/items/looting_mk1.json
@@ -123,7 +123,7 @@
       "he": "תאימות מגן"
     }
   },
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "plastic_parts": 6,
     "rubber_parts": 6
@@ -132,5 +132,8 @@
   "craftBench": [
     "equipment_bench",
     "workbench"
-  ]
+  ],
+  "salvagesInto": {
+    "plastic_parts": 3
+  }
 }

--- a/items/looting_mk2.json
+++ b/items/looting_mk2.json
@@ -120,7 +120,7 @@
   "weightKg": 2,
   "value": 2000,
   "imageFilename": "https://cdn.arctracker.io/items/looting_mk2.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "electrical_components": 2,
     "magnet": 3
@@ -129,5 +129,8 @@
     "magnet": 1,
     "electrical_components": 1
   },
-  "craftBench": "equipment_bench"
+  "craftBench": "equipment_bench",
+  "salvagesInto": {
+    "electrical_components": 1
+  }
 }

--- a/items/looting_mk3_cautious.json
+++ b/items/looting_mk3_cautious.json
@@ -120,10 +120,17 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/looting_mk3_cautious.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "advanced_electrical_components": 2,
     "processor": 3
   },
-  "craftBench": "equipment_bench"
+  "craftBench": "equipment_bench",
+  "recyclesInto": {
+    "advanced_electrical_components": 1,
+    "processor": 1
+  },
+  "salvagesInto": {
+    "electrical_components": 2
+  }
 }

--- a/items/looting_mk3_survivor.json
+++ b/items/looting_mk3_survivor.json
@@ -130,5 +130,8 @@
     "processor": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/looting_mk3_survivor.png",
-  "updatedAt": "11/11/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "electrical_components": 2
+  }
 }

--- a/items/lure_grenade.json
+++ b/items/lure_grenade.json
@@ -49,13 +49,16 @@
   "value": 1000,
   "weightKg": 0.4,
   "imageFilename": "https://cdn.arctracker.io/items/lure_grenade.png",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "speaker_component": 1,
     "electrical_components": 1
   },
   "craftBench": "utility_bench",
   "recyclesInto": {
+    "speaker_component": 1
+  },
+  "salvagesInto": {
     "speaker_component": 1
   }
 }

--- a/items/magnet.json
+++ b/items/magnet.json
@@ -48,11 +48,14 @@
   "rarity": "Uncommon",
   "value": 300,
   "recyclesInto": {
-    "metal_parts": 3
+    "metal_parts": 2
   },
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 0.25,
   "stackSize": 15,
   "foundIn": "Exodus",
-  "imageFilename": "https://cdn.arctracker.io/items/magnet.png"
+  "imageFilename": "https://cdn.arctracker.io/items/magnet.png",
+  "salvagesInto": {
+    "metal_parts": 1
+  }
 }

--- a/items/magnetic_accelerator.json
+++ b/items/magnetic_accelerator.json
@@ -55,10 +55,13 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/magnetic_accelerator.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "advanced_mechanical_components": 2,
     "arc_motion_core": 2
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "advanced_mechanical_components": 1
+  }
 }

--- a/items/magnetron.json
+++ b/items/magnetron.json
@@ -50,10 +50,13 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/magnetron.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "value": 6000,
   "recyclesInto": {
     "magnetic_accelerator": 1,
     "steel_spring": 1
+  },
+  "salvagesInto": {
+    "advanced_mechanical_components": 1
   }
 }

--- a/items/mechanical_components.json
+++ b/items/mechanical_components.json
@@ -52,7 +52,7 @@
     "rubber_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/mechanical_components.png",
-  "updatedAt": "11/23/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 0.5,
   "stackSize": 10,
   "foundIn": "Mechanical",
@@ -60,5 +60,8 @@
     "metal_parts": 7,
     "rubber_parts": 3
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "metal_parts": 3
+  }
 }

--- a/items/medium_gun_parts.json
+++ b/items/medium_gun_parts.json
@@ -54,9 +54,12 @@
   "foundIn": "Raider, Security",
   "stackSize": 5,
   "weightKg": 0.4,
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "simple_gun_parts": 4
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "simple_gun_parts": 1
+  }
 }

--- a/items/microscope.json
+++ b/items/microscope.json
@@ -50,10 +50,13 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/microscope.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "value": 3000,
   "recyclesInto": {
     "advanced_mechanical_components": 1,
     "magnet": 3
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
   }
 }

--- a/items/mini_centrifuge.json
+++ b/items/mini_centrifuge.json
@@ -49,11 +49,14 @@
   "weightKg": 1.5,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/mini_centrifuge.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "value": 3000,
   "stackSize": 3,
   "recyclesInto": {
     "advanced_mechanical_components": 1,
     "canister": 2
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
   }
 }

--- a/items/mod_components.json
+++ b/items/mod_components.json
@@ -51,7 +51,7 @@
   "stackSize": 5,
   "foundIn": "Security",
   "imageFilename": "https://cdn.arctracker.io/items/mod_components.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "mechanical_components": 1,
     "steel_spring": 1
@@ -60,5 +60,8 @@
     "steel_spring": 2,
     "mechanical_components": 2
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/muzzle_brake_i.json
+++ b/items/muzzle_brake_i.json
@@ -99,11 +99,14 @@
       "he": "רתע אופקי מופחת"
     }
   },
-  "updatedAt": "11/10/2025",
+  "updatedAt": "01/09/2026",
   "imageFilename": "https://cdn.arctracker.io/items/muzzle_brake_i.png",
   "recipe": {
     "metal_parts": 6,
     "wires": 1
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "salvagesInto": {
+    "metal_parts": 3
+  }
 }

--- a/items/muzzle_brake_ii.json
+++ b/items/muzzle_brake_ii.json
@@ -113,5 +113,8 @@
     "Stitcher"
   ],
   "imageFilename": "https://cdn.arctracker.io/items/muzzle_brake_ii.png",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/muzzle_brake_iii.json
+++ b/items/muzzle_brake_iii.json
@@ -120,12 +120,19 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/muzzle_brake_iii.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "wires": 8
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "recyclesInto": {
+    "mod_components": 1,
+    "wires": 2
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/noisemaker.json
+++ b/items/noisemaker.json
@@ -98,10 +98,16 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/noisemaker.png",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "speaker_component": 1,
     "plastic_parts": 2
   },
-  "craftBench": "in_raid"
+  "craftBench": "in_raid",
+  "recyclesInto": {
+    "speaker_component": 1
+  },
+  "salvagesInto": {
+    "speaker_component": 1
+  }
 }

--- a/items/number_plate.json
+++ b/items/number_plate.json
@@ -29,9 +29,9 @@
     "metal_parts": 3
   },
   "salvagesInto": {
-    "metal_parts": 1
+    "metal_parts": 2
   },
-  "updatedAt": "11/04/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "Can be recycled into metal parts.",
     "de": "Kann zu Metallteilen recycelt werden.",

--- a/items/oil.json
+++ b/items/oil.json
@@ -51,8 +51,11 @@
   "recyclesInto": {
     "chemicals": 3
   },
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 0.25,
   "stackSize": 15,
-  "foundIn": "Mechanical"
+  "foundIn": "Mechanical",
+  "salvagesInto": {
+    "chemicals": 1
+  }
 }

--- a/items/olives.json
+++ b/items/olives.json
@@ -28,7 +28,7 @@
   "recyclesInto": {
     "assorted_seeds": 2
   },
-  "updatedAt": "11/05/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "Can be consumed for a small amount of stamina.",
     "de": "Kann zum Gewinn einer kleinen Menge Ausdauer verzehrt werden.",
@@ -102,5 +102,8 @@
       "he": "זמן שימוש"
     }
   },
-  "imageFilename": "https://cdn.arctracker.io/items/olives.png"
+  "imageFilename": "https://cdn.arctracker.io/items/olives.png",
+  "salvagesInto": {
+    "assorted_seeds": 1
+  }
 }

--- a/items/osprey_i.json
+++ b/items/osprey_i.json
@@ -45,7 +45,7 @@
     "he": "רובה צלפים בריחי עם כוונת, בעל תפוקת נזק ודיוק אמינים."
   },
   "type": "Sniper Rifle",
-  "updatedAt": "11/12/2025",
+  "updatedAt": "01/09/2026",
   "value": 7000,
   "rarity": "Rare",
   "weightKg": 7,
@@ -197,5 +197,12 @@
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 2,
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "advanced_mechanical_components": 1,
+    "medium_gun_parts": 2
+  },
+  "salvagesInto": {
+    "medium_gun_parts": 2
+  }
 }

--- a/items/padded_stock.json
+++ b/items/padded_stock.json
@@ -189,11 +189,18 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/padded_stock.png",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "duct_tape": 5
   },
   "craftBench": "weapon_bench",
-  "stationLevelRequired": 3
+  "stationLevelRequired": 3,
+  "recyclesInto": {
+    "duct_tape": 1,
+    "mod_components": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/pop_trigger.json
+++ b/items/pop_trigger.json
@@ -29,7 +29,7 @@
     "crude_explosives": 1,
     "arc_alloy": 1
   },
-  "updatedAt": "11/01/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "Can be recycled into crafting materials.",
     "de": "Kann zu Herstellungsmaterialien recycelt werden.",
@@ -55,5 +55,8 @@
   "weightKg": 0.5,
   "stackSize": 3,
   "foundIn": "ARC",
-  "imageFilename": "https://cdn.arctracker.io/items/pop_trigger.png"
+  "imageFilename": "https://cdn.arctracker.io/items/pop_trigger.png",
+  "salvagesInto": {
+    "crude_explosives": 1
+  }
 }

--- a/items/portable_tv.json
+++ b/items/portable_tv.json
@@ -55,5 +55,8 @@
   "weightKg": 3,
   "stackSize": 1,
   "imageFilename": "https://cdn.arctracker.io/items/portable_tv.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "wires": 4
+  }
 }

--- a/items/power_cable.json
+++ b/items/power_cable.json
@@ -54,5 +54,8 @@
   "weightKg": 2,
   "foundIn": "Electrical, Residential, Commercial",
   "imageFilename": "https://cdn.arctracker.io/items/power_cable.png",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "wires": 3
+  }
 }

--- a/items/power_rod.json
+++ b/items/power_rod.json
@@ -54,11 +54,14 @@
     "arc_circuitry": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/power_rod.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "foundIn": "Exodus",
   "recipe": {
     "advanced_electrical_components": 2,
     "arc_circuitry": 2
   },
-  "craftBench": "refiner"
+  "craftBench": "refiner",
+  "salvagesInto": {
+    "advanced_electrical_components": 1
+  }
 }

--- a/items/prickly_pear.json
+++ b/items/prickly_pear.json
@@ -53,5 +53,8 @@
     "assorted_seeds": 3
   },
   "stackSize": 10,
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "assorted_seeds": 2
+  }
 }

--- a/items/processor.json
+++ b/items/processor.json
@@ -55,5 +55,8 @@
   "stackSize": 5,
   "foundIn": "Technological",
   "imageFilename": "https://cdn.arctracker.io/items/processor.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "plastic_parts": 2
+  }
 }

--- a/items/queen_reactor.json
+++ b/items/queen_reactor.json
@@ -55,5 +55,8 @@
   },
   "foundIn": "ARC",
   "imageFilename": "https://cdn.arctracker.io/items/queen_part.png",
-  "updatedAt": "10/30/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "power_rod": 1
+  }
 }

--- a/items/radio_relay.json
+++ b/items/radio_relay.json
@@ -51,9 +51,12 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/radio_relay.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "speaker_component": 2,
+    "sensors": 2
+  },
+  "salvagesInto": {
     "sensors": 2
   }
 }

--- a/items/rattler_i.json
+++ b/items/rattler_i.json
@@ -168,7 +168,7 @@
       "he": "חדירת שריון ARC"
     }
   },
-  "updatedAt": "12/16/2025",
+  "updatedAt": "01/09/2026",
   "imageFilename": "https://cdn.arctracker.io/items/rattler.png",
   "recipe": {
     "metal_parts": 16,
@@ -176,5 +176,8 @@
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 1,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "metal_parts": 4
+  }
 }

--- a/items/rattler_iii.json
+++ b/items/rattler_iii.json
@@ -188,7 +188,7 @@
   },
   "weightKg": 6,
   "imageFilename": "https://cdn.arctracker.io/items/rattler.png",
-  "updatedAt": "12/16/2025",
+  "updatedAt": "01/09/2026",
   "value": 5000,
   "craftBench": "weapon_bench",
   "upgradeCost": {
@@ -196,5 +196,12 @@
     "simple_gun_parts": 1
   },
   "stationLevelRequired": 1,
-  "isWeapon": true
+  "isWeapon": true,
+  "recyclesInto": {
+    "mechanical_components": 3,
+    "simple_gun_parts": 1
+  },
+  "salvagesInto": {
+    "metal_parts": 12
+  }
 }

--- a/items/recorder.json
+++ b/items/recorder.json
@@ -28,7 +28,7 @@
   "recyclesInto": {
     "plastic_parts": 10
   },
-  "updatedAt": "11/09/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "A playable recorder used to attract ARC's attention, and impress other Raiders.",
     "de": "Eine spielbare Flöte, mit der ARC angelockt oder andere Raider beeindruckt werden können.",
@@ -78,5 +78,8 @@
       "he": "עמידות"
     }
   },
-  "imageFilename": "https://cdn.arctracker.io/items/recorder.png"
+  "imageFilename": "https://cdn.arctracker.io/items/recorder.png",
+  "salvagesInto": {
+    "plastic_parts": 4
+  }
 }

--- a/items/red_light_stick.json
+++ b/items/red_light_stick.json
@@ -101,10 +101,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/red_light_stick.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 3
   },
   "craftBench": "utility_bench",
-  "stationLevelRequired": 1
+  "stationLevelRequired": 1,
+  "salvagesInto": {
+    "chemicals": 1
+  }
 }

--- a/items/remote_raider_flare.json
+++ b/items/remote_raider_flare.json
@@ -54,10 +54,13 @@
   "imageFilename": "https://cdn.arctracker.io/items/remote_raider_flare.png",
   "weightKg": 0.2,
   "stackSize": 3,
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 2,
     "rubber_parts": 4
   },
-  "craftBench": "utility_bench"
+  "craftBench": "utility_bench",
+  "salvagesInto": {
+    "chemicals": 1
+  }
 }

--- a/items/renegade_i.json
+++ b/items/renegade_i.json
@@ -170,7 +170,7 @@
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/renegade.png",
-  "updatedAt": "11/12/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "advanced_mechanical_components": 2,
     "medium_gun_parts": 3,
@@ -178,5 +178,8 @@
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 2
+  }
 }

--- a/items/renegade_ii.json
+++ b/items/renegade_ii.json
@@ -224,6 +224,13 @@
   "agility": 55.8,
   "stealth": 16,
   "imageFilename": "https://cdn.arctracker.io/items/renegade.png",
-  "updatedAt": "11/12/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "recyclesInto": {
+    "advanced_mechanical_components": 2,
+    "medium_gun_parts": 2
+  },
+  "salvagesInto": {
+    "medium_gun_parts": 2
+  }
 }

--- a/items/renegade_iii.json
+++ b/items/renegade_iii.json
@@ -224,6 +224,13 @@
   "agility": 55.8,
   "stealth": 16,
   "imageFilename": "https://cdn.arctracker.io/items/renegade.png",
-  "updatedAt": "11/12/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "recyclesInto": {
+    "advanced_mechanical_components": 2,
+    "medium_gun_parts": 3
+  },
+  "salvagesInto": {
+    "medium_gun_parts": 3
+  }
 }

--- a/items/renegade_iv.json
+++ b/items/renegade_iv.json
@@ -224,6 +224,13 @@
   "agility": 55.8,
   "stealth": 16,
   "imageFilename": "https://cdn.arctracker.io/items/renegade.png",
-  "updatedAt": "11/12/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "recyclesInto": {
+    "advanced_mechanical_components": 3,
+    "medium_gun_parts": 3
+  },
+  "salvagesInto": {
+    "medium_gun_parts": 3
+  }
 }

--- a/items/rocket_thruster.json
+++ b/items/rocket_thruster.json
@@ -51,9 +51,12 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/rocket_thruster.png",
-  "updatedAt": "11/01/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "synthesized_fuel": 2,
     "metal_parts": 6
+  },
+  "salvagesInto": {
+    "synthesized_fuel": 1
   }
 }

--- a/items/rocketeer_driver.json
+++ b/items/rocketeer_driver.json
@@ -29,7 +29,7 @@
     "advanced_electrical_components": 2,
     "arc_alloy": 3
   },
-  "updatedAt": "11/2/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "Can be recycled into crafting materials.",
     "de": "Kann zu Herstellungsmaterialien recycelt werden.",
@@ -55,5 +55,8 @@
   "weightKg": 1,
   "stackSize": 3,
   "foundIn": "ARC",
-  "imageFilename": "https://cdn.arctracker.io/items/rocketeer_driver.png"
+  "imageFilename": "https://cdn.arctracker.io/items/rocketeer_driver.png",
+  "salvagesInto": {
+    "arc_circuitry": 2
+  }
 }

--- a/items/roots.json
+++ b/items/roots.json
@@ -51,8 +51,11 @@
   "recyclesInto": {
     "assorted_seeds": 1
   },
-  "updatedAt": "10/31/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 0.2,
   "stackSize": 10,
-  "foundIn": "Nature"
+  "foundIn": "Nature",
+  "salvagesInto": {
+    "assorted_seeds": 1
+  }
 }

--- a/items/rope.json
+++ b/items/rope.json
@@ -28,7 +28,7 @@
   "recyclesInto": {
     "fabric": 5
   },
-  "updatedAt": "10/31/2025",
+  "updatedAt": "01/09/2026",
   "description": {
     "en": "Used in crafting. Used to craft: Zipline, Snap Hook",
     "de": "Wird bei der Herstellung verwendet. Zur Herstellung von: Seilrutsche, Karabinerhaken",
@@ -54,5 +54,8 @@
   "foundIn": "Residential, Commercial",
   "weightKg": 0.3,
   "stackSize": 5,
-  "imageFilename": "https://cdn.arctracker.io/items/rope.png"
+  "imageFilename": "https://cdn.arctracker.io/items/rope.png",
+  "salvagesInto": {
+    "fabric": 2
+  }
 }

--- a/items/rotary_encoder.json
+++ b/items/rotary_encoder.json
@@ -49,11 +49,14 @@
   "weightKg": 1.5,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/rotary_encoder.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "value": 3000,
   "stackSize": 3,
   "recyclesInto": {
     "electrical_components": 2,
+    "processor": 2
+  },
+  "salvagesInto": {
     "processor": 2
   }
 }

--- a/items/ruined_baton.json
+++ b/items/ruined_baton.json
@@ -55,5 +55,8 @@
     "rubber_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/ruined_baton.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "metal_parts": 4
+  }
 }

--- a/items/ruined_handcuffs.json
+++ b/items/ruined_handcuffs.json
@@ -54,5 +54,8 @@
   },
   "foundIn": "Security",
   "imageFilename": "https://cdn.arctracker.io/items/ruined_handcuffs.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "metal_parts": 4
+  }
 }

--- a/items/rusted_gear.json
+++ b/items/rusted_gear.json
@@ -52,8 +52,11 @@
     "mechanical_components": 2
   },
   "foundIn": "Industrial",
-  "updatedAt": "11/04/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 3,
   "stackSize": 3,
-  "imageFilename": "https://cdn.arctracker.io/items/rusted_gear.png"
+  "imageFilename": "https://cdn.arctracker.io/items/rusted_gear.png",
+  "salvagesInto": {
+    "metal_parts": 12
+  }
 }

--- a/items/rusted_shut_medical_kit.json
+++ b/items/rusted_shut_medical_kit.json
@@ -55,5 +55,8 @@
     "antiseptic": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/rusted_shut_medical_kit.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "syringe": 2
+  }
 }

--- a/items/sample_cleaner.json
+++ b/items/sample_cleaner.json
@@ -51,9 +51,12 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/sample_cleaner.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "electrical_components": 2,
     "assorted_seeds": 14
+  },
+  "salvagesInto": {
+    "assorted_seeds": 12
   }
 }

--- a/items/seeker_grenade.json
+++ b/items/seeker_grenade.json
@@ -98,15 +98,18 @@
     }
   },
   "recyclesInto": {
-    "chemicals": 1
+    "crude_explosives": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/seeker_grenade.png",
-  "updatedAt": "11/13/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "crude_explosives": 1,
     "arc_alloy": 2
   },
   "craftBench": "explosives_bench",
   "stationLevelRequired": 1,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "chemicals": 3
+  }
 }

--- a/items/shaker.json
+++ b/items/shaker.json
@@ -51,5 +51,11 @@
   "stackSize": 1,
   "value": 1000,
   "imageFilename": "https://cdn.arctracker.io/items/shaker.png",
-  "updatedAt": "12/16/2025"
+  "updatedAt": "01/09/2026",
+  "recyclesInto": {
+    "plastic_parts": 10
+  },
+  "salvagesInto": {
+    "plastic_parts": 4
+  }
 }

--- a/items/shield_recharger.json
+++ b/items/shield_recharger.json
@@ -121,7 +121,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/shield_recharger.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "rubber_parts": 5,
     "arc_powercell": 1
@@ -133,5 +133,8 @@
   ],
   "recyclesInto": {
     "rubber_parts": 4
+  },
+  "salvagesInto": {
+    "rubber_parts": 3
   }
 }

--- a/items/shotgun_choke_i.json
+++ b/items/shotgun_choke_i.json
@@ -74,10 +74,16 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/shotgun_choke_i.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "metal_parts": 6,
     "wires": 1
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "recyclesInto": {
+    "metal_parts": 5
+  },
+  "salvagesInto": {
+    "metal_parts": 3
+  }
 }

--- a/items/shotgun_choke_ii.json
+++ b/items/shotgun_choke_ii.json
@@ -82,12 +82,15 @@
     "Vulcano"
   ],
   "imageFilename": "https://cdn.arctracker.io/items/shotgun_choke_ii.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 2,
     "wires": 4
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 2,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/shotgun_choke_iii.json
+++ b/items/shotgun_choke_iii.json
@@ -120,12 +120,19 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/shotgun_choke_iii.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "wires": 8
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "recyclesInto": {
+    "mod_components": 1,
+    "wires": 2
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/shotgun_silencer.json
+++ b/items/shotgun_silencer.json
@@ -74,12 +74,19 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/shotgun_silencer.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "wires": 8
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "recyclesInto": {
+    "mod_components": 1,
+    "wires": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/showstopper.json
+++ b/items/showstopper.json
@@ -121,7 +121,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/showstopper.png",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "electrical_components": 1,
     "battery": 2
@@ -132,5 +132,8 @@
   },
   "craftBench": "explosives_bench",
   "stationLevelRequired": 3,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "battery": 2
+  }
 }

--- a/items/shrapnel_grenade.json
+++ b/items/shrapnel_grenade.json
@@ -101,11 +101,14 @@
   },
   "weightKg": 0.15,
   "stackSize": 5,
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "crude_explosives": 1,
     "steel_spring": 2
   },
   "craftBench": "explosives_bench",
-  "imageFilename": "https://cdn.arctracker.io/items/shrapnel_grenade.png"
+  "imageFilename": "https://cdn.arctracker.io/items/shrapnel_grenade.png",
+  "salvagesInto": {
+    "crude_explosives": 1
+  }
 }

--- a/items/shredder_gyro.json
+++ b/items/shredder_gyro.json
@@ -51,9 +51,12 @@
   "stackSize": 3,
   "foundIn": "ARC",
   "imageFilename": "https://cdn.arctracker.io/items/shredder_gyro.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "mechanical_components": 3,
     "arc_alloy": 3
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
   }
 }

--- a/items/signal_amplifier.json
+++ b/items/signal_amplifier.json
@@ -49,11 +49,14 @@
   "weightKg": 1.5,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/signal_amplifier.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "value": 3000,
   "stackSize": 3,
   "recyclesInto": {
     "electrical_components": 2,
+    "voltage_converter": 2
+  },
+  "salvagesInto": {
     "voltage_converter": 2
   }
 }

--- a/items/silencer_i.json
+++ b/items/silencer_i.json
@@ -45,7 +45,7 @@
     "he": "מפחית מעט את עוצמת הרעש בעת הירי."
   },
   "type": "Modification",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "rarity": "Uncommon",
   "effects": {
     "Noise Reduction": {
@@ -80,5 +80,12 @@
     "wires": 4
   },
   "craftBench": "weapon_bench",
-  "stationLevelRequired": 2
+  "stationLevelRequired": 2,
+  "recyclesInto": {
+    "mechanical_components": 1,
+    "wires": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/silencer_ii.json
+++ b/items/silencer_ii.json
@@ -74,11 +74,18 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/silencer_ii.png",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "wires": 8
   },
   "craftBench": "weapon_bench",
-  "stationLevelRequired": 3
+  "stationLevelRequired": 3,
+  "recyclesInto": {
+    "mod_components": 1,
+    "wires": 2
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/silencer_iii.json
+++ b/items/silencer_iii.json
@@ -108,10 +108,10 @@
     "wires": 3
   },
   "salvagesInto": {
-    "mod_components": 1
+    "mod_components": 2
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "updatedAt": "11/16/2025",
+  "updatedAt": "01/09/2026",
   "imageFilename": "https://cdn.arctracker.io/items/silencer_iii.png"
 }

--- a/items/simple_gun_parts.json
+++ b/items/simple_gun_parts.json
@@ -50,9 +50,12 @@
   "recyclesInto": {
     "metal_parts": 2
   },
-  "updatedAt": "10/31/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 0.3,
   "stackSize": 10,
   "foundIn": "Raider, Security",
-  "imageFilename": "https://cdn.arctracker.io/items/simple_gun_parts.png"
+  "imageFilename": "https://cdn.arctracker.io/items/simple_gun_parts.png",
+  "salvagesInto": {
+    "metal_parts": 1
+  }
 }

--- a/items/smoke_grenade.json
+++ b/items/smoke_grenade.json
@@ -102,12 +102,15 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/smoke_grenade.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 14,
     "canister": 1
   },
   "craftBench": "utility_bench",
   "stationLevelRequired": 2,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "chemicals": 3
+  }
 }

--- a/items/snap_blast_grenade.json
+++ b/items/snap_blast_grenade.json
@@ -102,10 +102,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/snap_blast_grenade.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "crude_explosives": 2,
     "magnet": 1
   },
-  "craftBench": "explosives_bench"
+  "craftBench": "explosives_bench",
+  "salvagesInto": {
+    "chemicals": 2
+  }
 }

--- a/items/snap_hook.json
+++ b/items/snap_hook.json
@@ -107,5 +107,8 @@
     "rope": 3
   },
   "craftBench": "utility_bench",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "advanced_electrical_components": 2
+  }
 }

--- a/items/snitch_scanner.json
+++ b/items/snitch_scanner.json
@@ -52,10 +52,10 @@
     "electrical_components": 2
   },
   "salvagesInto": {
-    "electrical_components": 1
+    "electrical_components": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/snitch_scanner.png",
-  "updatedAt": "11/13/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 0.75,
   "stackSize": 3,
   "foundIn": "ARC"

--- a/items/speaker_component.json
+++ b/items/speaker_component.json
@@ -55,5 +55,8 @@
   "stackSize": 5,
   "foundIn": "Commercial",
   "imageFilename": "https://cdn.arctracker.io/items/speaker_component.png",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "plastic_parts": 2
+  }
 }

--- a/items/spectrometer.json
+++ b/items/spectrometer.json
@@ -51,9 +51,12 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/spectrometer.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "advanced_electrical_components": 1,
     "sensors": 1
+  },
+  "salvagesInto": {
+    "electrical_components": 2
   }
 }

--- a/items/spectrum_analyzer.json
+++ b/items/spectrum_analyzer.json
@@ -50,9 +50,12 @@
   "weightKg": 1.5,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/spectrum_analyzer.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "sensors": 1,
     "exodus_modules": 1
+  },
+  "salvagesInto": {
+    "processor": 2
   }
 }

--- a/items/stable_stock_ii.json
+++ b/items/stable_stock_ii.json
@@ -131,12 +131,15 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/stable_stock_ii.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 2,
     "duct_tape": 3
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 2,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/stable_stock_iii.json
+++ b/items/stable_stock_iii.json
@@ -143,12 +143,19 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/stable_stock_iii.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mod_components": 2,
     "duct_tape": 5
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 3,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "recyclesInto": {
+    "duct_tape": 2,
+    "mod_components": 1
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/steel_spring.json
+++ b/items/steel_spring.json
@@ -52,10 +52,10 @@
     "metal_parts": 2
   },
   "salvagesInto": {
-    "metal_parts": 2
+    "metal_parts": 1
   },
   "weightKg": 0.25,
   "stackSize": 15,
   "foundIn": "Industrial",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026"
 }

--- a/items/sterilized_bandage.json
+++ b/items/sterilized_bandage.json
@@ -120,11 +120,18 @@
       "he": "זמן שימוש"
     }
   },
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "stackSize": 3,
   "recipe": {
     "antiseptic": 1,
     "durable_cloth": 2
   },
-  "craftBench": "med_station"
+  "craftBench": "med_station",
+  "recyclesInto": {
+    "antiseptic": 1,
+    "fabric": 1
+  },
+  "salvagesInto": {
+    "durable_cloth": 1
+  }
 }

--- a/items/surge_shield_recharger.json
+++ b/items/surge_shield_recharger.json
@@ -98,7 +98,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/surge_shield_recharger.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "electrical_components": 1
   },
@@ -106,5 +106,8 @@
     "electrical_components": 1,
     "advanced_arc_powercell": 1
   },
-  "craftBench": "med_station"
+  "craftBench": "med_station",
+  "salvagesInto": {
+    "plastic_parts": 5
+  }
 }

--- a/items/synthesized_fuel.json
+++ b/items/synthesized_fuel.json
@@ -55,5 +55,8 @@
     "plastic_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/synthesized_fuel.png",
-  "updatedAt": "12/07/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "oil": 1
+  }
 }

--- a/items/tactical_mk1.json
+++ b/items/tactical_mk1.json
@@ -124,10 +124,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/tactical_i.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "plastic_parts": 6,
     "rubber_parts": 6
   },
-  "craftBench": "equipment_bench"
+  "craftBench": "equipment_bench",
+  "salvagesInto": {
+    "plastic_parts": 3
+  }
 }

--- a/items/tactical_mk2.json
+++ b/items/tactical_mk2.json
@@ -48,7 +48,7 @@
   "rarity": "Rare",
   "value": 2000,
   "imageFilename": "https://cdn.arctracker.io/items/tactical_i.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "effects": {
     "Durability": {
       "en": "Durability",
@@ -122,12 +122,15 @@
   },
   "weightKg": 2,
   "recyclesInto": {
-    "advanced_electrical_components": 1,
-    "magnet": 1
+    "magnet": 1,
+    "electrical_components": 1
   },
   "recipe": {
     "electrical_components": 2,
     "magnet": 3
   },
-  "craftBench": "equipment_bench"
+  "craftBench": "equipment_bench",
+  "salvagesInto": {
+    "electrical_components": 1
+  }
 }

--- a/items/tactical_mk3_defensive.json
+++ b/items/tactical_mk3_defensive.json
@@ -131,5 +131,8 @@
   "weightKg": 5,
   "value": 5000,
   "imageFilename": "https://cdn.arctracker.io/items/tactical_mk3_defensive.png",
-  "updatedAt": "11/05/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "electrical_components": 2
+  }
 }

--- a/items/tactical_mk3_healing.json
+++ b/items/tactical_mk3_healing.json
@@ -124,11 +124,14 @@
   "weightKg": 4,
   "value": 5000,
   "imageFilename": "https://cdn.arctracker.io/items/tactical_mk3_healing.png",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "advanced_electrical_components": 2,
     "processor": 3
   },
   "craftBench": "equipment_bench",
-  "stationLevelRequired": 3
+  "stationLevelRequired": 3,
+  "salvagesInto": {
+    "electrical_components": 2
+  }
 }

--- a/items/tattered_arc_lining.json
+++ b/items/tattered_arc_lining.json
@@ -54,5 +54,8 @@
   "stackSize": 3,
   "foundIn": "ARC",
   "imageFilename": "https://cdn.arctracker.io/items/tattered_arc_lining.png",
-  "updatedAt": "11/06/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "fabric": 5
+  }
 }

--- a/items/telemetry_transceiver.json
+++ b/items/telemetry_transceiver.json
@@ -50,10 +50,13 @@
   "stackSize": 3,
   "foundIn": "Exodus",
   "imageFilename": "https://cdn.arctracker.io/items/telemetry_transceiver.png",
-  "updatedAt": "11/14/2025",
+  "updatedAt": "01/09/2026",
   "value": 3000,
   "recyclesInto": {
     "advanced_electrical_components": 1,
     "processor": 1
+  },
+  "salvagesInto": {
+    "electrical_components": 2
   }
 }

--- a/items/tempest_i.json
+++ b/items/tempest_i.json
@@ -178,6 +178,9 @@
   "stationLevelRequired": 3,
   "blueprintLocked": true,
   "imageFilename": "https://cdn.arctracker.io/items/tempest.png",
-  "updatedAt": "12/7/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 2
+  }
 }

--- a/items/tempest_ii.json
+++ b/items/tempest_ii.json
@@ -221,6 +221,9 @@
     "medium_gun_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/tempest.png",
-  "updatedAt": "11/11/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 3
+  }
 }

--- a/items/tempest_iii.json
+++ b/items/tempest_iii.json
@@ -221,6 +221,9 @@
     "medium_gun_parts": 4
   },
   "imageFilename": "https://cdn.arctracker.io/items/tempest.png",
-  "updatedAt": "11/11/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 4
+  }
 }

--- a/items/tempest_iv.json
+++ b/items/tempest_iv.json
@@ -221,6 +221,9 @@
     "medium_gun_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/tempest.png",
-  "updatedAt": "11/11/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 5
+  }
 }

--- a/items/torn_blanket.json
+++ b/items/torn_blanket.json
@@ -54,5 +54,8 @@
   "stackSize": 3,
   "foundIn": "Residential, Medical",
   "imageFilename": "https://cdn.arctracker.io/items/torn_blanket.png",
-  "updatedAt": "11/01/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "fabric": 5
+  }
 }

--- a/items/torrente_i.json
+++ b/items/torrente_i.json
@@ -169,7 +169,7 @@
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/torrente.png",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "advanced_mechanical_components": 2,
     "medium_gun_parts": 3,
@@ -177,5 +177,8 @@
   },
   "craftBench": "weapon_bench",
   "weightKg": 12,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 2
+  }
 }

--- a/items/torrente_ii.json
+++ b/items/torrente_ii.json
@@ -196,7 +196,10 @@
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/torrente.png",
-  "updatedAt": "11/06/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 12,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 2
+  }
 }

--- a/items/torrente_iii.json
+++ b/items/torrente_iii.json
@@ -196,7 +196,10 @@
     "medium_gun_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/torrente.png",
-  "updatedAt": "11/06/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 12,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 3
+  }
 }

--- a/items/torrente_iv.json
+++ b/items/torrente_iv.json
@@ -196,7 +196,10 @@
     "medium_gun_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/torrente.png",
-  "updatedAt": "11/06/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 12,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 3
+  }
 }

--- a/items/trailblazer.json
+++ b/items/trailblazer.json
@@ -107,5 +107,8 @@
     "crude_explosives": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/trailblazer.png",
-  "updatedAt": "11/14/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "crude_explosives": 1
+  }
 }

--- a/items/trigger_nade.json
+++ b/items/trigger_nade.json
@@ -98,7 +98,7 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/trigger_nade.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "chemicals": 1,
     "processor": 1
@@ -107,5 +107,8 @@
     "crude_explosives": 2,
     "processor": 1
   },
-  "craftBench": "explosives_bench"
+  "craftBench": "explosives_bench",
+  "salvagesInto": {
+    "processor": 1
+  }
 }

--- a/items/turbo_pump.json
+++ b/items/turbo_pump.json
@@ -54,6 +54,9 @@
   "weightKg": 3,
   "stackSize": 3,
   "foundIn": "Exodus",
-  "updatedAt": "11/04/2025",
-  "imageFilename": "https://cdn.arctracker.io/items/turbo_pump.png"
+  "updatedAt": "01/09/2026",
+  "imageFilename": "https://cdn.arctracker.io/items/turbo_pump.png",
+  "salvagesInto": {
+    "steel_spring": 3
+  }
 }

--- a/items/venator_i.json
+++ b/items/venator_i.json
@@ -200,6 +200,9 @@
   "craftBench": "weapon_bench",
   "stationLevelRequired": 2,
   "imageFilename": "https://cdn.arctracker.io/items/venator.png",
-  "updatedAt": "11/20/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 2
+  }
 }

--- a/items/venator_ii.json
+++ b/items/venator_ii.json
@@ -239,11 +239,14 @@
     "medium_gun_parts": 2
   },
   "craftBench": "weapon_bench",
-  "updatedAt": "11/20/2025",
+  "updatedAt": "01/09/2026",
   "upgradeCost": {
     "advanced_mechanical_components": 1,
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/venator.png",
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 2
+  }
 }

--- a/items/venator_iii.json
+++ b/items/venator_iii.json
@@ -239,11 +239,14 @@
     "medium_gun_parts": 3
   },
   "craftBench": "weapon_bench",
-  "updatedAt": "11/20/2025",
+  "updatedAt": "01/09/2026",
   "upgradeCost": {
     "advanced_mechanical_components": 1,
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/venator.png",
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 3
+  }
 }

--- a/items/venator_iv.json
+++ b/items/venator_iv.json
@@ -239,11 +239,14 @@
     "medium_gun_parts": 3
   },
   "craftBench": "weapon_bench",
-  "updatedAt": "11/20/2025",
+  "updatedAt": "01/09/2026",
   "upgradeCost": {
     "advanced_mechanical_components": 2,
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/venator.png",
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "medium_gun_parts": 3
+  }
 }

--- a/items/vertical_grip_i.json
+++ b/items/vertical_grip_i.json
@@ -74,10 +74,16 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/vertical_grip_i.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "plastic_parts": 6,
     "duct_tape": 1
   },
-  "craftBench": "weapon_bench"
+  "craftBench": "weapon_bench",
+  "recyclesInto": {
+    "plastic_parts": 6
+  },
+  "salvagesInto": {
+    "plastic_parts": 3
+  }
 }

--- a/items/vertical_grip_ii.json
+++ b/items/vertical_grip_ii.json
@@ -85,12 +85,15 @@
     "Stitcher"
   ],
   "imageFilename": "https://cdn.arctracker.io/items/vertical_grip_ii.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "mechanical_components": 2,
     "duct_tape": 3
   },
   "craftBench": "weapon_bench",
   "stationLevelRequired": 2,
-  "blueprintLocked": true
+  "blueprintLocked": true,
+  "salvagesInto": {
+    "mechanical_components": 1
+  }
 }

--- a/items/vertical_grip_iii.json
+++ b/items/vertical_grip_iii.json
@@ -102,5 +102,12 @@
     "duct_tape": 5
   },
   "imageFilename": "https://cdn.arctracker.io/items/vertical_grip_iii.png",
-  "updatedAt": "11/07/2025"
+  "updatedAt": "01/09/2026",
+  "recyclesInto": {
+    "duct_tape": 2,
+    "mechanical_components": 2
+  },
+  "salvagesInto": {
+    "mechanical_components": 2
+  }
 }

--- a/items/vita_shot.json
+++ b/items/vita_shot.json
@@ -107,5 +107,8 @@
     "chemicals": 4,
     "syringe": 1
   },
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026",
+  "salvagesInto": {
+    "syringe": 1
+  }
 }

--- a/items/voltage_converter.json
+++ b/items/voltage_converter.json
@@ -48,12 +48,15 @@
   "rarity": "Rare",
   "value": 500,
   "imageFilename": "https://cdn.arctracker.io/items/voltage_converter.png",
-  "updatedAt": "11/01/2025",
+  "updatedAt": "01/09/2026",
   "weightKg": 0.3,
   "stackSize": 5,
   "foundIn": "Electrical",
   "recyclesInto": {
     "wires": 1,
     "rubber_parts": 1
+  },
+  "salvagesInto": {
+    "rubber_parts": 2
   }
 }

--- a/items/vulcano_i.json
+++ b/items/vulcano_i.json
@@ -57,7 +57,7 @@
   "reducedDurabilityBurnRate": 23,
   "stationLevelRequired": 3,
   "imageFilename": "https://cdn.arctracker.io/items/vulcano.png",
-  "updatedAt": "11/12/2025",
+  "updatedAt": "01/09/2026",
   "value": 10000,
   "weightKg": 8,
   "recyclesInto": {
@@ -188,5 +188,8 @@
       "he": "חדירת שריון ARC"
     }
   },
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "heavy_gun_parts": 2
+  }
 }

--- a/items/vulcano_ii.json
+++ b/items/vulcano_ii.json
@@ -56,7 +56,7 @@
   "reducedReloadTime": 26,
   "reducedDurabilityBurnRate": 46,
   "imageFilename": "https://cdn.arctracker.io/items/vulcano.png",
-  "updatedAt": "11/12/2025",
+  "updatedAt": "01/09/2026",
   "value": 13000,
   "weightKg": 9.25,
   "stackSize": 1,
@@ -233,5 +233,8 @@
     "heavy_gun_parts": 2
   },
   "stationLevelRequired": 1,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "heavy_gun_parts": 3
+  }
 }

--- a/items/vulcano_iii.json
+++ b/items/vulcano_iii.json
@@ -262,12 +262,15 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/vulcano.png",
-  "updatedAt": "11/12/2025",
+  "updatedAt": "01/09/2026",
   "craftBench": "weapon_bench",
   "upgradeCost": {
     "advanced_mechanical_components": 2,
     "heavy_gun_parts": 1
   },
   "stationLevelRequired": 1,
-  "isWeapon": true
+  "isWeapon": true,
+  "salvagesInto": {
+    "heavy_gun_parts": 4
+  }
 }

--- a/items/vulcano_iv.json
+++ b/items/vulcano_iv.json
@@ -228,6 +228,9 @@
   "stealth": 15,
   "weightKg": 8,
   "imageFilename": "https://cdn.arctracker.io/items/vulcano.png",
-  "updatedAt": "11/12/2025",
-  "isWeapon": true
+  "updatedAt": "01/09/2026",
+  "isWeapon": true,
+  "salvagesInto": {
+    "heavy_gun_parts": 5
+  }
 }

--- a/items/wires.json
+++ b/items/wires.json
@@ -49,7 +49,7 @@
   "rarity": "Uncommon",
   "value": 200,
   "recyclesInto": {
-    "rubber_parts": 2
+    "rubber_parts": 3
   },
   "salvagesInto": {
     "rubber_parts": 1
@@ -58,5 +58,5 @@
   "weightKg": 0.25,
   "stackSize": 15,
   "foundIn": "Electrical, Technological",
-  "updatedAt": "11/03/2025"
+  "updatedAt": "01/09/2026"
 }

--- a/items/wolfpack.json
+++ b/items/wolfpack.json
@@ -98,14 +98,17 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/wolfpack.png",
-  "updatedAt": "11/21/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
-    "crude_explosives": 1,
-    "arc_motion_core": 1
+    "arc_motion_core": 1,
+    "explosive_compound": 1
   },
   "recipe": {
     "explosive_compound": 3,
     "arc_motion_core": 2
   },
-  "craftBench": "explosives_bench"
+  "craftBench": "explosives_bench",
+  "salvagesInto": {
+    "explosive_compound": 2
+  }
 }

--- a/items/yellow_light_stick.json
+++ b/items/yellow_light_stick.json
@@ -101,10 +101,13 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/yellow_light_stick.png",
-  "updatedAt": "12/31/2025",
+  "updatedAt": "01/09/2026",
   "recipe": {
     "chemicals": 3
   },
   "craftBench": "explosives_bench",
-  "stationLevelRequired": 3
+  "stationLevelRequired": 3,
+  "salvagesInto": {
+    "chemicals": 1
+  }
 }

--- a/items/zipline.json
+++ b/items/zipline.json
@@ -49,7 +49,7 @@
   "weightKg": 0.4,
   "value": 1000,
   "imageFilename": "https://cdn.arctracker.io/items/zipline.png",
-  "updatedAt": "11/05/2025",
+  "updatedAt": "01/09/2026",
   "recyclesInto": {
     "rope": 1,
     "metal_parts": 1
@@ -58,5 +58,8 @@
   "recipe": {
     "rope": 1,
     "mechanical_components": 1
+  },
+  "salvagesInto": {
+    "rope": 1
   }
 }


### PR DESCRIPTION
Updated version of https://github.com/RaidTheory/arcraiders-data/pull/118

* Most items had missing salvagesInto (what you get when salvaging during an raid).
* Some items had missing recyclesInto (what you get when recycling it later in the inventory)
* Fixed 21 items with incorrect information (amounts / materials):
  * **Advanced Mechanical Components** - Removed wires output
  * **Bicycle Pump** - Removed incorrect canister data
  * **Compensator III** - Fixed component type (mechanical → mod)
  * **Damaged ARC Motion Core** - Updated quantities (2→3, 1→2)
  * **Deadline** - Added missing arc_circuitry
  * **Deflated Football** - Corrected rubber/fabric amounts (15→9)
  * **Explosive Mine** - Fixed output items (chemicals → oil)
  * **Ferro IV** - Corrected salvage outputs (metal_parts → simple_gun_parts)
  * **Hairpin II** - Fixed material types (plastic → rubber)
  * **Kettle I & II** - Corrected material types (plastic → metal)
  * **Laboratory Reagents** - Fixed quantities (2→16, 2→3)
  * **Magnet** - Updated metal parts amount (3→2)
  * **Number Plate** - Updated salvage quantity (1→2)
  * **Seeker Grenade** - Changed chemicals to crude_explosives
  * **Silencer III** - Updated salvage output (1→2)
  * **Snitch Scanner** - Updated salvage output (1→2)
  * **Steel Spring** - Updated salvage output (2→1)
  * **Tactical Mk. 2** - Fixed component type (advanced → regular)
  * **Wires** - Updated recycling output (2→3)
  * **Wolfpack** - Changed output type (crude_explosives → explosive_compound)
