### PR TITLE
Fix type of "Matriarch Reactor"

### DIFF
--- a/items/matriarch_reactor.json
+++ b/items/matriarch_reactor.json
@@ -44,7 +44,7 @@
     "zh-CN": "可回收为制作材料。",
     "zh-TW": "可回收為製作材料。"
   },
-  "type": "Material",
+  "type": "Recyclable",
   "rarity": "Legendary",
   "value": 13000,
   "weightKg": 10,


### PR DESCRIPTION
`"type": "Material"` does not exist

Solves #191 