### PR TITLE
Fix some salvage/recycle infos (Damaged ARC Motion Core and Wires)

### DIFF
--- a/items/damaged_arc_motion_core.json
+++ b/items/damaged_arc_motion_core.json
@@ -51,11 +51,11 @@
   "weightKg": 0.25,
   "stackSize": 5,
   "recyclesInto": {
-    "arc_alloy": 3
-  },
-  "salvagesInto": {
     "arc_alloy": 2
   },
+  "salvagesInto": {
+    "arc_alloy": 1
+  },
   "imageFilename": "https://cdn.arctracker.io/items/damaged_arc_motion_core.png",
-  "updatedAt": "01/13/2026"
+  "updatedAt": "01/20/2026"
 }

--- a/items/wires.json
+++ b/items/wires.json
@@ -51,12 +51,12 @@
   "weightKg": 0.25,
   "stackSize": 15,
   "recyclesInto": {
-    "rubber_parts": 3
+    "rubber_parts": 2
   },
   "salvagesInto": {
     "rubber_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/wires.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "01/20/2026",
   "tip": "Wires are an uncommon item used to craft weapon mods that can be recycled into crafting materials."
 }


### PR DESCRIPTION
Damaged ARC Motion Core (damaged_arc_motion_core.json)
* recyclesInto: Changed arc_alloy: 3 → 2
* salvagesInto: Changed arc_alloy: 2 → 1

Wires (wires.json)
* recyclesInto: Changed rubber_parts: 3 → 2