### PR TITLE
Yet more schedule changes from Tuesday (Jan 20th) update

### DIFF
--- a/map-events/map-events.json
+++ b/map-events/map-events.json
@@ -165,6 +165,7 @@
         "1": "night-raid",
         "9": "electromagnetic-storm",
         "13": "locked-gate",
+        "17": "night-raid",
         "21": "locked-gate"
       },
       "minor": {
@@ -173,7 +174,6 @@
         "8": "matriarch",
         "11": "harvester",
         "14": "matriarch",
-        "17": "prospecting-probes",
         "20": "harvester",
         "23": "husk-graveyard"
       }


### PR DESCRIPTION
Changes from this Tuesday update, adding more Trial relevant events:

## The Dam:
* Major events: No changes (Night Raids and Electromagnetic Storms remain)
* Minor events: Lush Blooms removed from hour 1, replaced with Prospecting Probes; Uncovered Caches at hour 17 replaced with Husk Graveyard

## Buried City:
* No changes (schedule remains the same)

## The Spaceport:
* Major events: No changes (Hidden Bunkers remain at hours 8 and 16)
* Minor events: Lush Blooms at hour 11 replaced with Prospecting Probes

## Blue Gate:
* Major events: Night Raid and Locked Gate removed from hours 5 and 17
* Minor events: Uncovered Caches removed and replaced with Husk Graveyard (hours 5, 23); Lush Blooms at hour 17 replaced with Prospecting Probes

## Screenshot for Tuesday, Jan 20th
### UTC 11

![schedule-11](https://github.com/user-attachments/assets/ed995413-76e0-48d4-b38c-fbad17fa6051)

### UTC 12

![schedule-12](https://github.com/user-attachments/assets/3d437cb3-46f6-458e-b2e1-7016f3d7edd9)

### UTC 13

![schedule-13](https://github.com/user-attachments/assets/5ceabafe-631e-4c7c-9c8c-aa41d455a7c1)

### UTC 15

![schedule-15](https://github.com/user-attachments/assets/d6d1563e-e1d7-43d3-91b0-2d6be8475174)

### UTC 16

![schedule-16](https://github.com/user-attachments/assets/79ef8983-47f9-441c-ab8d-2fd0ebea6699)

### UTC 17

![schedule-17](https://github.com/user-attachments/assets/cd52a43b-ce27-4894-8ca7-52ed2dd92057)

### UTC 19 - still matching

![schedule-19](https://github.com/user-attachments/assets/e272e3dc-701b-4741-bdf4-4ad04e109fa1)
