### PR TITLE
Update prettier config to support "disabled" in projects.json

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -114,6 +114,7 @@ const json_sort_orders = {
       name: "projects",
       rules: {
         id: null,
+        disabled: null,
         name: null,
         description: null,
         phases: null,


### PR DESCRIPTION
Makes `bun run check` not fail due to the new property added in cc60f7a32ec2da62edf3bf31302d6e60a1a4dd5a 