### PR TITLE
Wrong translation for Broken Guidance System in German.

### DIFF
--- a/items/broken_guidance_system.json
+++ b/items/broken_guidance_system.json
@@ -2,7 +2,7 @@
   "id": "broken_guidance_system",
   "name": {
     "da": "Ødelagt styringssystem",
-    "de": "Defektes Leitsystem",
+    "de": "Kaputtes Leitsystem",
     "en": "Broken Guidance System",
     "es": "Sistema de guía roto",
     "fr": "Système de Guidage Cassé",


### PR DESCRIPTION
Defektes -> "Kaputtes"