### PR TITLE
Add missing "en" description for some quests

### DIFF
--- a/quests/down_to_earth.json
+++ b/quests/down_to_earth.json
@@ -31,7 +31,8 @@
     }
   ],
   "description": {
-    "de": "Raider berichten schon lange von seltsam aussehenden Kisten, die aus defekten ARC-Sonden fallen. Wenn wir die irgendwie öffnen könnten, verstehen wir vielleicht, wonach sie suchen."
+    "de": "Raider berichten schon lange von seltsam aussehenden Kisten, die aus defekten ARC-Sonden fallen. Wenn wir die irgendwie öffnen könnten, verstehen wir vielleicht, wonach sie suchen.",
+    "en": "Raiders have long reported peculiar-looking crates dropping down from malfunctioning ARC Probes. If we can figure out a way to crack them open, we might get a better understanding of what it is they’re after."
   },
   "objectivesOneRound": true,
   "objectives": [

--- a/quests/off_the_radar.json
+++ b/quests/off_the_radar.json
@@ -31,7 +31,8 @@
     }
   ],
   "description": {
-    "de": "Der Schaden hier unten war ziemlich übel, aber die Infrastruktur oben hat es noch schlimmer erwischt. Ich hab noch einige Antennen, die seit dem Sturm nicht mehr funktionieren."
+    "de": "Der Schaden hier unten war ziemlich übel, aber die Infrastruktur oben hat es noch schlimmer erwischt. Ich hab noch einige Antennen, die seit dem Sturm nicht mehr funktionieren.",
+    "en": "The damage down here was pretty bad, but our Topside infrastructure was hit even harder. I still have several antennas that stopped working after the storm."
   },
   "objectivesOneRound": true,
   "objectives": [

--- a/quests/safe_passage.json
+++ b/quests/safe_passage.json
@@ -34,7 +34,8 @@
     }
   ],
   "description": {
-    "de": "Ich hab Gerüchte über ein Signal gehört, das Shani aufgefangen hat. Die ARC passen sich ständig an, und ich bin mir sicher, dass das nicht ihr letztes Warnsignal sein wird. Na ja, wenn sie ein Wettrüsten wollen, dann kriegen sie eins."
+    "de": "Ich hab Gerüchte über ein Signal gehört, das Shani aufgefangen hat. Die ARC passen sich ständig an, und ich bin mir sicher, dass das nicht ihr letztes Warnsignal sein wird. Na ja, wenn sie ein Wettrüsten wollen, dann kriegen sie eins.",
+    "en": "I heard rumors about some signal Shani picked up. ARC is constantly adapting, and I'm sure this won’t be their last warning sign. Well, if it’s an arms race they want, they can get one."
   },
   "objectives": [
     {


### PR DESCRIPTION
This made the "de" (German) descriptions appear on arctracker.io.