### PR TITLE
Add missing weights for tattered clothes and prickly pear

### DIFF
--- a/items/prickly_pear.json
+++ b/items/prickly_pear.json
@@ -48,6 +48,7 @@
   "rarity": "Common",
   "foundIn": "Nature",
   "value": 640,
+  "weightKg": 0.2,
   "stackSize": 10,
   "recyclesInto": {
     "assorted_seeds": 3

--- a/items/tattered_clothes.json
+++ b/items/tattered_clothes.json
@@ -48,6 +48,7 @@
   "rarity": "Uncommon",
   "foundIn": "Residential",
   "value": 640,
+  "weightKg": 0.8,
   "stackSize": 3,
   "recyclesInto": {
     "fabric": 11


### PR DESCRIPTION
Tattered clothes and prickly pear are missing weights. I noticed because I built this to quickly view all item data and when sorting by weight, they are missing: https://aludvik.github.io/arcdata-public/