### PR TITLE
Fix some recycling / upgrading incorrect infos in items

### DIFF
--- a/items/advanced_electrical_components.json
+++ b/items/advanced_electrical_components.json
@@ -50,7 +50,7 @@
   "value": 1750,
   "weightKg": 1,
   "stackSize": 5,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "electrical_components": 2,
@@ -64,6 +64,6 @@
     "electrical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/advanced_electrical_components.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/advanced_mechanical_components.json
+++ b/items/advanced_mechanical_components.json
@@ -50,7 +50,7 @@
   "value": 1750,
   "weightKg": 1,
   "stackSize": 5,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "mechanical_components": 2,
@@ -64,6 +64,6 @@
     "mechanical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/advanced_mechanical_components.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/agave_juice.json
+++ b/items/agave_juice.json
@@ -152,5 +152,6 @@
     "empty_wine_bottle": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/agave_juice.png",
-  "updatedAt": "02/25/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/alien_duck.json
+++ b/items/alien_duck.json
@@ -49,8 +49,7 @@
   "value": 1000,
   "weightKg": 0.3,
   "stackSize": 15,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/alien_duck.png",
-  "updatedAt": "02/01/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "1.13"
 }

--- a/items/antiseptic.json
+++ b/items/antiseptic.json
@@ -50,7 +50,7 @@
   "value": 1000,
   "weightKg": 1,
   "stackSize": 5,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "chemicals": 10,
@@ -63,6 +63,6 @@
     "chemicals": 5
   },
   "imageFilename": "https://cdn.arctracker.io/items/antiseptic.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/anvil_i.json
+++ b/items/anvil_i.json
@@ -181,12 +181,8 @@
   "salvagesInto": {
     "simple_gun_parts": 2
   },
-  "upgradeCost": {
-    "mechanical_components": 3,
-    "simple_gun_parts": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/anvil.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "muzzle": [

--- a/items/anvil_ii.json
+++ b/items/anvil_ii.json
@@ -222,11 +222,11 @@
     "simple_gun_parts": 3
   },
   "upgradeCost": {
-    "heavy_gun_parts": 1,
-    "mechanical_components": 4
+    "mechanical_components": 3,
+    "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/anvil.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "muzzle": [

--- a/items/arc_alloy.json
+++ b/items/arc_alloy.json
@@ -50,10 +50,6 @@
   "value": 200,
   "weightKg": 0.25,
   "stackSize": 15,
-  "craftBench": "in_raid",
-  "recipe": {
-    "wasp_driver": 1
-  },
   "recyclesInto": {
     "metal_parts": 2
   },
@@ -61,6 +57,6 @@
     "metal_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/arc_alloy.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/arc_circuitry.json
+++ b/items/arc_circuitry.json
@@ -50,7 +50,7 @@
   "value": 1000,
   "weightKg": 0.3,
   "stackSize": 5,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "arc_alloy": 8
@@ -62,6 +62,6 @@
     "arc_alloy": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/arc_circuitry.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/arc_powercell.json
+++ b/items/arc_powercell.json
@@ -121,17 +121,7 @@
       "zh-TW": "使用時間"
     }
   },
-  "craftBench": "in_raid",
-  "recipe": {
-    "advanced_arc_powercell": 1
-  },
-  "recyclesInto": {
-    "arc_alloy": 1
-  },
-  "salvagesInto": {
-    "metal_parts": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/arc_powercell.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/arpeggio_i.json
+++ b/items/arpeggio_i.json
@@ -180,12 +180,8 @@
   "salvagesInto": {
     "simple_gun_parts": 2
   },
-  "upgradeCost": {
-    "mechanical_components": 4,
-    "simple_gun_parts": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/arpeggio.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/arpeggio_ii.json
+++ b/items/arpeggio_ii.json
@@ -222,11 +222,11 @@
     "simple_gun_parts": 3
   },
   "upgradeCost": {
-    "mechanical_components": 5,
-    "medium_gun_parts": 1
+    "mechanical_components": 4,
+    "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/arpeggio.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/assorted_seeds.json
+++ b/items/assorted_seeds.json
@@ -50,11 +50,7 @@
   "value": 100,
   "weightKg": 0.05,
   "stackSize": 100,
-  "craftBench": "in_raid",
-  "recipe": {
-    "agave": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/assorted_seeds.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/battery.json
+++ b/items/battery.json
@@ -50,10 +50,6 @@
   "value": 250,
   "weightKg": 0.25,
   "stackSize": 15,
-  "craftBench": "in_raid",
-  "recipe": {
-    "jolt_mine": 1
-  },
   "recyclesInto": {
     "metal_parts": 2
   },
@@ -61,7 +57,7 @@
     "metal_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/battery.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/bettina_i.json
+++ b/items/bettina_i.json
@@ -182,12 +182,8 @@
   "salvagesInto": {
     "advanced_mechanical_components": 1
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 1,
-    "heavy_gun_parts": 2
-  },
   "imageFilename": "https://cdn.arctracker.io/items/bettina.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/bettina_iii.json
+++ b/items/bettina_iii.json
@@ -222,11 +222,11 @@
     "advanced_mechanical_components": 3
   },
   "upgradeCost": {
-    "advanced_mechanical_components": 2,
+    "advanced_mechanical_components": 1,
     "heavy_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/bettina.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/blaze_grenade_trap.json
+++ b/items/blaze_grenade_trap.json
@@ -49,7 +49,6 @@
   "value": 1000,
   "weightKg": 0.3,
   "stackSize": 3,
-  "blueprintLocked": true,
   "effects": {
     "Damage": {
       "value": "5/s",
@@ -105,6 +104,6 @@
     "wires": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/blaze_grenade_trap.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/bobcat_i.json
+++ b/items/bobcat_i.json
@@ -320,12 +320,8 @@
   "salvagesInto": {
     "light_gun_parts": 2
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 2,
-    "light_gun_parts": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/bobcat.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/bobcat_ii.json
+++ b/items/bobcat_ii.json
@@ -384,10 +384,10 @@
   },
   "upgradeCost": {
     "advanced_mechanical_components": 2,
-    "light_gun_parts": 3
+    "light_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/bobcat.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/burletta_i.json
+++ b/items/burletta_i.json
@@ -181,12 +181,8 @@
   "salvagesInto": {
     "simple_gun_parts": 2
   },
-  "upgradeCost": {
-    "mechanical_components": 3,
-    "simple_gun_parts": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "durability": 100,
   "modSlots": {

--- a/items/burletta_iii.json
+++ b/items/burletta_iii.json
@@ -59,11 +59,11 @@
     "simple_gun_parts": 3
   },
   "upgradeCost": {
-    "light_gun_parts": 1,
-    "mechanical_components": 4
+    "mechanical_components": 3,
+    "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/burletta.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "magazine": [

--- a/items/canister.json
+++ b/items/canister.json
@@ -50,10 +50,6 @@
   "value": 300,
   "weightKg": 0.25,
   "stackSize": 15,
-  "craftBench": "in_raid",
-  "recipe": {
-    "bicycle_pump": 1
-  },
   "recyclesInto": {
     "plastic_parts": 3
   },
@@ -61,7 +57,7 @@
     "plastic_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/canister.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/chemicals.json
+++ b/items/chemicals.json
@@ -50,12 +50,8 @@
   "value": 50,
   "weightKg": 0.15,
   "stackSize": 50,
-  "craftBench": "in_raid",
-  "recipe": {
-    "gas_grenade": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/chemicals.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/combat_mk1.json
+++ b/items/combat_mk1.json
@@ -134,7 +134,8 @@
     "plastic_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/combat_i.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "plastic_parts": 3,
     "rubber_parts": 3

--- a/items/combat_mk2.json
+++ b/items/combat_mk2.json
@@ -157,7 +157,8 @@
     "electrical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/combat_i.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "electrical_components": 1,
     "magnet": 1

--- a/items/combat_mk3_aggressive.json
+++ b/items/combat_mk3_aggressive.json
@@ -250,7 +250,8 @@
     "electrical_components": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/combat_mk3_aggressive.png",
-  "updatedAt": "01/20/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "advanced_electrical_components": 1,
     "processor": 2

--- a/items/combat_mk3_flanking.json
+++ b/items/combat_mk3_flanking.json
@@ -250,7 +250,8 @@
     "electrical_components": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/combat_mk3_flanking.png",
-  "updatedAt": "01/20/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "advanced_electrical_components": 1,
     "processor": 2

--- a/items/crude_explosives.json
+++ b/items/crude_explosives.json
@@ -98,7 +98,7 @@
       "zh-TW": "範圍"
     }
   },
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 1,
   "recipe": {
     "chemicals": 6
@@ -110,6 +110,6 @@
     "chemicals": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/crude_explosives.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/dam_controlled_access_zone_key.json
+++ b/items/dam_controlled_access_zone_key.json
@@ -48,6 +48,6 @@
   "rarity": "Epic",
   "value": 100,
   "weightKg": 0.25,
-  "updatedAt": "02/24/2026",
-  "imageFilename": "https://cdn.arctracker.io/items/dam_testing_annex_key.png"
+  "imageFilename": "https://cdn.arctracker.io/items/dam_testing_annex_key.png",
+  "updatedAt": "02/24/2026"
 }

--- a/items/damaged_arc_powercell.json
+++ b/items/damaged_arc_powercell.json
@@ -57,5 +57,6 @@
     "metal_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/damaged_arc_powercell.png",
-  "updatedAt": "01/13/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/doodly_duck.json
+++ b/items/doodly_duck.json
@@ -49,8 +49,7 @@
   "value": 3000,
   "weightKg": 0.3,
   "stackSize": 15,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/doodly_duck.png",
-  "updatedAt": "02/01/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "1.13"
 }

--- a/items/durable_cloth.json
+++ b/items/durable_cloth.json
@@ -50,7 +50,7 @@
   "value": 640,
   "weightKg": 0.25,
   "stackSize": 10,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 1,
   "recipe": {
     "fabric": 14
@@ -62,6 +62,6 @@
     "fabric": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/durable_cloth.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/dusty_film_reel.json
+++ b/items/dusty_film_reel.json
@@ -49,5 +49,6 @@
   "value": 0,
   "weightKg": 0,
   "stackSize": 1,
-  "updatedAt": "02/24/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "1.17"
 }

--- a/items/electrical_components.json
+++ b/items/electrical_components.json
@@ -50,7 +50,7 @@
   "value": 640,
   "weightKg": 0.5,
   "stackSize": 10,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 1,
   "recipe": {
     "plastic_parts": 8,
@@ -64,6 +64,6 @@
     "plastic_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/electrical_components.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/empty_wine_bottle.json
+++ b/items/empty_wine_bottle.json
@@ -50,8 +50,7 @@
   "value": 1000,
   "weightKg": 0.2,
   "stackSize": 5,
-  "craftBench": "in_raid",
   "imageFilename": "https://cdn.arctracker.io/items/empty_wine_bottle.png",
-  "updatedAt": "11/04/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/energy_clip.json
+++ b/items/energy_clip.json
@@ -46,7 +46,7 @@
   },
   "type": "Ammunition",
   "rarity": "Rare",
-  "value": 1000,
+  "value": 200,
   "weightKg": 0.3,
   "stackSize": 5,
   "craftQuantity": 5,
@@ -58,7 +58,7 @@
     "battery": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/energy_clip.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/20/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/exodus_modules.json
+++ b/items/exodus_modules.json
@@ -50,10 +50,6 @@
   "value": 2750,
   "weightKg": 1,
   "stackSize": 3,
-  "craftBench": "in_raid",
-  "recipe": {
-    "ion_sputter": 1
-  },
   "recyclesInto": {
     "magnet": 2,
     "processor": 2
@@ -62,7 +58,7 @@
     "processor": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/exodus_modules.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/explosive_compound.json
+++ b/items/explosive_compound.json
@@ -50,7 +50,7 @@
   "value": 1000,
   "weightKg": 0.3,
   "stackSize": 5,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "crude_explosives": 2,
@@ -63,6 +63,6 @@
     "crude_explosives": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/explosive_compound.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/fabric.json
+++ b/items/fabric.json
@@ -121,15 +121,8 @@
       "zh-TW": "使用時間"
     }
   },
-  "craftBench": "in_raid",
-  "recipe": {
-    "tattered_clothes": 1
-  },
-  "salvagesInto": {
-    "bandage": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/fabric.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/familiar_duck.json
+++ b/items/familiar_duck.json
@@ -49,8 +49,7 @@
   "value": 7000,
   "weightKg": 0.3,
   "stackSize": 15,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/familiar_duck.png",
-  "updatedAt": "02/01/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "1.13"
 }

--- a/items/ferro_i.json
+++ b/items/ferro_i.json
@@ -180,11 +180,8 @@
   "salvagesInto": {
     "metal_parts": 2
   },
-  "upgradeCost": {
-    "metal_parts": 7
-  },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/ferro_ii.json
+++ b/items/ferro_ii.json
@@ -176,11 +176,10 @@
     "metal_parts": 4
   },
   "upgradeCost": {
-    "metal_parts": 9,
-    "simple_gun_parts": 1
+    "metal_parts": 7
   },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/ferro_iii.json
+++ b/items/ferro_iii.json
@@ -199,11 +199,11 @@
     "simple_gun_parts": 1
   },
   "upgradeCost": {
-    "mechanical_components": 1,
+    "metal_parts": 9,
     "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/ferro.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/fireball_burner.json
+++ b/items/fireball_burner.json
@@ -121,10 +121,6 @@
       "zh-TW": "範圍"
     }
   },
-  "craftBench": "in_raid",
-  "recipe": {
-    "flame_spray": 1
-  },
   "recyclesInto": {
     "arc_alloy": 1,
     "crude_explosives": 1
@@ -133,6 +129,6 @@
     "arc_alloy": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/fireball_burner.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/flashy_duck.json
+++ b/items/flashy_duck.json
@@ -49,8 +49,7 @@
   "value": 3000,
   "weightKg": 0.3,
   "stackSize": 15,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/flashy_duck.png",
-  "updatedAt": "02/01/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "1.13"
 }

--- a/items/free_loadout_augment.json
+++ b/items/free_loadout_augment.json
@@ -77,5 +77,6 @@
     "Shield Compatibility": null
   },
   "imageFilename": "https://cdn.arctracker.io/items/free_loadout_augment.png",
-  "updatedAt": "02/24/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/gas_grenade_trap.json
+++ b/items/gas_grenade_trap.json
@@ -49,7 +49,6 @@
   "value": 300,
   "weightKg": 0.25,
   "stackSize": 3,
-  "blueprintLocked": true,
   "effects": {
     "Duration": {
       "value": "20s",
@@ -128,6 +127,6 @@
     "wires": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/gas_grenade_trap.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/gentle_duck.json
+++ b/items/gentle_duck.json
@@ -49,8 +49,7 @@
   "value": 1000,
   "weightKg": 0.3,
   "stackSize": 15,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/gentle_duck.png",
-  "updatedAt": "02/01/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "1.13"
 }

--- a/items/hairpin_i.json
+++ b/items/hairpin_i.json
@@ -203,11 +203,8 @@
   "salvagesInto": {
     "metal_parts": 2
   },
-  "upgradeCost": {
-    "metal_parts": 8
-  },
   "imageFilename": "https://cdn.arctracker.io/items/hairpin_i.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "magazine": [

--- a/items/hairpin_ii.json
+++ b/items/hairpin_ii.json
@@ -245,11 +245,10 @@
     "metal_parts": 4
   },
   "upgradeCost": {
-    "metal_parts": 9,
-    "simple_gun_parts": 1
+    "metal_parts": 8
   },
   "imageFilename": "https://cdn.arctracker.io/items/hairpin_i.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "magazine": [

--- a/items/hairpin_iii.json
+++ b/items/hairpin_iii.json
@@ -245,11 +245,11 @@
     "simple_gun_parts": 1
   },
   "upgradeCost": {
-    "mechanical_components": 1,
+    "metal_parts": 9,
     "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/hairpin_i.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "magazine": [

--- a/items/heavy_gun_parts.json
+++ b/items/heavy_gun_parts.json
@@ -51,7 +51,7 @@
   "weightKg": 0.5,
   "stackSize": 5,
   "blueprintLocked": true,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "simple_gun_parts": 4
@@ -63,7 +63,7 @@
     "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/heavy_gun_parts.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/hullcracker_i.json
+++ b/items/hullcracker_i.json
@@ -182,12 +182,8 @@
   "salvagesInto": {
     "heavy_gun_parts": 2
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 1,
-    "heavy_gun_parts": 2
-  },
   "imageFilename": "https://cdn.arctracker.io/items/hullcracker.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/hullcracker_ii.json
+++ b/items/hullcracker_ii.json
@@ -199,11 +199,11 @@
     "heavy_gun_parts": 3
   },
   "upgradeCost": {
-    "advanced_mechanical_components": 2,
-    "heavy_gun_parts": 1
+    "advanced_mechanical_components": 1,
+    "heavy_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/hullcracker.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "agility": 67.9,
   "damage": 100,

--- a/items/hullcracker_iii.json
+++ b/items/hullcracker_iii.json
@@ -200,10 +200,10 @@
   },
   "upgradeCost": {
     "advanced_mechanical_components": 2,
-    "heavy_gun_parts": 3
+    "heavy_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/hullcracker.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "agility": 67.9,
   "damage": 100,

--- a/items/il_toro_i.json
+++ b/items/il_toro_i.json
@@ -181,12 +181,8 @@
   "salvagesInto": {
     "simple_gun_parts": 2
   },
-  "upgradeCost": {
-    "mechanical_components": 3,
-    "simple_gun_parts": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/il_toro.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/il_toro_ii.json
+++ b/items/il_toro_ii.json
@@ -199,11 +199,11 @@
     "simple_gun_parts": 3
   },
   "upgradeCost": {
-    "heavy_gun_parts": 1,
-    "mechanical_components": 4
+    "mechanical_components": 3,
+    "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/il_toro.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/kettle_i.json
+++ b/items/kettle_i.json
@@ -180,12 +180,8 @@
   "salvagesInto": {
     "metal_parts": 3
   },
-  "upgradeCost": {
-    "metal_parts": 8,
-    "plastic_parts": 10
-  },
   "imageFilename": "https://cdn.arctracker.io/items/kettle.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/kettle_ii.json
+++ b/items/kettle_ii.json
@@ -59,11 +59,11 @@
     "metal_parts": 6
   },
   "upgradeCost": {
-    "metal_parts": 10,
-    "simple_gun_parts": 1
+    "metal_parts": 8,
+    "plastic_parts": 10
   },
   "imageFilename": "https://cdn.arctracker.io/items/kettle.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/kettle_iii.json
+++ b/items/kettle_iii.json
@@ -199,11 +199,11 @@
     "simple_gun_parts": 1
   },
   "upgradeCost": {
-    "mechanical_components": 3,
+    "metal_parts": 10,
     "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/kettle.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/library_book.json
+++ b/items/library_book.json
@@ -28,5 +28,6 @@
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
-  "updatedAt": "02/23/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/light_gun_parts.json
+++ b/items/light_gun_parts.json
@@ -51,7 +51,7 @@
   "weightKg": 0.3,
   "stackSize": 5,
   "blueprintLocked": true,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "simple_gun_parts": 4
@@ -63,7 +63,7 @@
     "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/light_gun_parts.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/looting_mk1.json
+++ b/items/looting_mk1.json
@@ -134,7 +134,8 @@
     "plastic_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/looting_mk1.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "plastic_parts": 3,
     "rubber_parts": 3

--- a/items/looting_mk2.json
+++ b/items/looting_mk2.json
@@ -134,7 +134,8 @@
     "electrical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/looting_mk2.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "electrical_components": 1,
     "magnet": 1

--- a/items/looting_mk3_cautious.json
+++ b/items/looting_mk3_cautious.json
@@ -134,7 +134,8 @@
     "electrical_components": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/looting_mk3_cautious.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "advanced_electrical_components": 1,
     "processor": 2

--- a/items/looting_mk3_safekeeper.json
+++ b/items/looting_mk3_safekeeper.json
@@ -135,5 +135,6 @@
     "electrical_components": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/looting_mk3_safekeeper.png",
-  "updatedAt": "02/24/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/looting_mk3_survivor_blueprint.json
+++ b/items/looting_mk3_survivor_blueprint.json
@@ -49,5 +49,6 @@
   "value": 5000,
   "weightKg": 0,
   "imageFilename": "https://cdn.arctracker.io/items/looting_mk3_survivor_blueprint.png",
-  "updatedAt": "01/13/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/lure_grenade_trap.json
+++ b/items/lure_grenade_trap.json
@@ -49,7 +49,6 @@
   "value": 1000,
   "weightKg": 0.25,
   "stackSize": 3,
-  "blueprintLocked": true,
   "effects": {
     "Duration": {
       "value": "15s",
@@ -105,6 +104,6 @@
     "wires": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/lure_grenade_trap.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/magnet.json
+++ b/items/magnet.json
@@ -50,10 +50,6 @@
   "value": 300,
   "weightKg": 0.25,
   "stackSize": 15,
-  "craftBench": "in_raid",
-  "recipe": {
-    "industrial_magnet": 1
-  },
   "recyclesInto": {
     "metal_parts": 2
   },
@@ -61,7 +57,7 @@
     "metal_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/magnet.png",
-  "updatedAt": "01/09/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/magnetic_accelerator.json
+++ b/items/magnetic_accelerator.json
@@ -50,7 +50,7 @@
   "value": 5500,
   "weightKg": 1,
   "stackSize": 3,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 3,
   "recipe": {
     "advanced_mechanical_components": 2,
@@ -64,6 +64,6 @@
     "advanced_mechanical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/magnetic_accelerator.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/major_aivas_mementos.json
+++ b/items/major_aivas_mementos.json
@@ -29,5 +29,6 @@
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/major_aivas_mementos.png",
-  "updatedAt": "02/23/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/mechanical_components.json
+++ b/items/mechanical_components.json
@@ -50,7 +50,7 @@
   "value": 640,
   "weightKg": 0.5,
   "stackSize": 10,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 1,
   "recipe": {
     "metal_parts": 7,
@@ -64,6 +64,6 @@
     "metal_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/mechanical_components.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/medium_gun_parts.json
+++ b/items/medium_gun_parts.json
@@ -51,7 +51,7 @@
   "weightKg": 0.4,
   "stackSize": 5,
   "blueprintLocked": true,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "simple_gun_parts": 4
@@ -63,7 +63,7 @@
     "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/medium_gun_parts.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/metal_parts.json
+++ b/items/metal_parts.json
@@ -50,12 +50,8 @@
   "value": 75,
   "weightKg": 0.1,
   "stackSize": 50,
-  "craftBench": "in_raid",
-  "recipe": {
-    "damaged_tick_pod": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/metal_parts.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/mod_components.json
+++ b/items/mod_components.json
@@ -50,7 +50,7 @@
   "value": 1750,
   "weightKg": 1,
   "stackSize": 5,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 2,
   "recipe": {
     "mechanical_components": 2,
@@ -64,6 +64,6 @@
     "mechanical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/mod_components.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/oil.json
+++ b/items/oil.json
@@ -50,10 +50,6 @@
   "value": 300,
   "weightKg": 0.25,
   "stackSize": 15,
-  "craftBench": "in_raid",
-  "recipe": {
-    "motor": 1
-  },
   "recyclesInto": {
     "chemicals": 3
   },
@@ -61,7 +57,7 @@
     "chemicals": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/oil.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/osprey_i.json
+++ b/items/osprey_i.json
@@ -205,12 +205,8 @@
   "salvagesInto": {
     "medium_gun_parts": 2
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 1,
-    "medium_gun_parts": 2
-  },
   "imageFilename": "https://cdn.arctracker.io/items/osprey.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/osprey_iii.json
+++ b/items/osprey_iii.json
@@ -245,11 +245,11 @@
     "medium_gun_parts": 3
   },
   "upgradeCost": {
-    "advanced_mechanical_components": 2,
+    "advanced_mechanical_components": 1,
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/osprey.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "agility": 45.9,
   "damage": 45,

--- a/items/painted_box.json
+++ b/items/painted_box.json
@@ -50,8 +50,7 @@
   "value": 2000,
   "weightKg": 0.3,
   "stackSize": 3,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/painted_box.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/plastic_parts.json
+++ b/items/plastic_parts.json
@@ -50,12 +50,8 @@
   "value": 60,
   "weightKg": 0.1,
   "stackSize": 50,
-  "craftBench": "in_raid",
-  "recipe": {
-    "surge_shield_recharger": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/plastic_parts.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/playing_cards.json
+++ b/items/playing_cards.json
@@ -50,8 +50,7 @@
   "value": 5000,
   "weightKg": 0.2,
   "stackSize": 3,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/playing_cards.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/possibly_toxic_plant.json
+++ b/items/possibly_toxic_plant.json
@@ -29,5 +29,6 @@
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/possibly_toxic_plant.png",
-  "updatedAt": "02/23/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/pottery.json
+++ b/items/pottery.json
@@ -50,8 +50,7 @@
   "value": 2000,
   "weightKg": 0.3,
   "stackSize": 3,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/pottery.png",
-  "updatedAt": "11/03/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/power_rod.json
+++ b/items/power_rod.json
@@ -50,7 +50,7 @@
   "value": 5000,
   "weightKg": 2,
   "stackSize": 3,
-  "craftBench": ["in_raid", "refiner"],
+  "craftBench": "refiner",
   "stationLevelRequired": 3,
   "recipe": {
     "advanced_electrical_components": 2,
@@ -64,6 +64,6 @@
     "advanced_electrical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/power_rod.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/processor.json
+++ b/items/processor.json
@@ -50,10 +50,6 @@
   "value": 500,
   "weightKg": 0.2,
   "stackSize": 5,
-  "craftBench": "in_raid",
-  "recipe": {
-    "projector": 1
-  },
   "recyclesInto": {
     "plastic_parts": 1,
     "wires": 1
@@ -62,7 +58,7 @@
     "plastic_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/processor.png",
-  "updatedAt": "01/09/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/project_heartwood_blueprints.json
+++ b/items/project_heartwood_blueprints.json
@@ -49,5 +49,6 @@
   "value": 0,
   "weightKg": 0,
   "stackSize": 1,
-  "updatedAt": "02/24/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "1.17"
 }

--- a/items/rattler_i.json
+++ b/items/rattler_i.json
@@ -179,12 +179,8 @@
   "salvagesInto": {
     "metal_parts": 4
   },
-  "upgradeCost": {
-    "metal_parts": 10,
-    "rubber_parts": 10
-  },
   "imageFilename": "https://cdn.arctracker.io/items/rattler.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/rattler_ii.json
+++ b/items/rattler_ii.json
@@ -175,11 +175,11 @@
     "metal_parts": 8
   },
   "upgradeCost": {
-    "mechanical_components": 3,
-    "simple_gun_parts": 1
+    "metal_parts": 10,
+    "rubber_parts": 10
   },
   "imageFilename": "https://cdn.arctracker.io/items/rattler.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "agility": 54.8,
   "damage": 9,

--- a/items/red_coral_jewelry.json
+++ b/items/red_coral_jewelry.json
@@ -50,8 +50,7 @@
   "value": 5000,
   "weightKg": 0.3,
   "stackSize": 3,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/red_coral_jewelry.png",
-  "updatedAt": "11/04/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/renegade_i.json
+++ b/items/renegade_i.json
@@ -181,12 +181,8 @@
   "salvagesInto": {
     "medium_gun_parts": 2
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 1,
-    "medium_gun_parts": 2
-  },
   "imageFilename": "https://cdn.arctracker.io/items/renegade.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "magazine": [

--- a/items/renegade_iii.json
+++ b/items/renegade_iii.json
@@ -222,11 +222,11 @@
     "medium_gun_parts": 3
   },
   "upgradeCost": {
-    "advanced_mechanical_components": 2,
+    "advanced_mechanical_components": 1,
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/renegade.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "agility": 55.8,
   "damage": 35,

--- a/items/resin.json
+++ b/items/resin.json
@@ -121,8 +121,7 @@
       "zh-TW": "使用時間"
     }
   },
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/resin.png",
-  "updatedAt": "11/04/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/rope.json
+++ b/items/rope.json
@@ -50,10 +50,6 @@
   "value": 500,
   "weightKg": 0.3,
   "stackSize": 5,
-  "craftBench": "in_raid",
-  "recipe": {
-    "zipline": 1
-  },
   "recyclesInto": {
     "fabric": 5
   },
@@ -61,7 +57,7 @@
     "fabric": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/rope.png",
-  "updatedAt": "01/09/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/rubber_parts.json
+++ b/items/rubber_parts.json
@@ -50,12 +50,8 @@
   "value": 50,
   "weightKg": 0.1,
   "stackSize": 50,
-  "craftBench": "in_raid",
-  "recipe": {
-    "rubber_pad": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/rubber_parts.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/sensors.json
+++ b/items/sensors.json
@@ -50,10 +50,6 @@
   "value": 500,
   "weightKg": 0.3,
   "stackSize": 5,
-  "craftBench": "in_raid",
-  "recipe": {
-    "broken_handheld_radio": 1
-  },
   "recyclesInto": {
     "metal_parts": 1,
     "wires": 1
@@ -62,7 +58,7 @@
     "wires": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/sensors.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/silver_teaspoon_set.json
+++ b/items/silver_teaspoon_set.json
@@ -50,8 +50,7 @@
   "value": 3000,
   "weightKg": 0.3,
   "stackSize": 3,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/silver_teaspoon_set.png",
-  "updatedAt": "12/07/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/simple_gun_parts.json
+++ b/items/simple_gun_parts.json
@@ -50,10 +50,6 @@
   "value": 330,
   "weightKg": 0.3,
   "stackSize": 10,
-  "craftBench": "in_raid",
-  "recipe": {
-    "il_toro_ii": 1
-  },
   "recyclesInto": {
     "metal_parts": 2
   },
@@ -61,7 +57,7 @@
     "metal_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/simple_gun_parts.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/smoke_grenade_trap.json
+++ b/items/smoke_grenade_trap.json
@@ -49,7 +49,6 @@
   "value": 640,
   "weightKg": 0.3,
   "stackSize": 3,
-  "blueprintLocked": true,
   "effects": {
     "Duration": {
       "value": "20s",
@@ -105,6 +104,6 @@
     "wires": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/smoke_grenade_trap.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/speaker_component.json
+++ b/items/speaker_component.json
@@ -50,10 +50,6 @@
   "value": 500,
   "weightKg": 0.3,
   "stackSize": 5,
-  "craftBench": "in_raid",
-  "recipe": {
-    "noisemaker": 1
-  },
   "recyclesInto": {
     "plastic_parts": 2,
     "rubber_parts": 3
@@ -62,7 +58,7 @@
     "plastic_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/speaker_component.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/statuette.json
+++ b/items/statuette.json
@@ -50,8 +50,7 @@
   "value": 3000,
   "weightKg": 0.3,
   "stackSize": 3,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/statuette.png",
-  "updatedAt": "11/01/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/steel_spring.json
+++ b/items/steel_spring.json
@@ -50,10 +50,6 @@
   "value": 300,
   "weightKg": 0.25,
   "stackSize": 15,
-  "craftBench": "in_raid",
-  "recipe": {
-    "cooling_coil": 1
-  },
   "recyclesInto": {
     "metal_parts": 2
   },
@@ -61,7 +57,7 @@
     "metal_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/steel_spring.png",
-  "updatedAt": "01/09/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/stitcher_i.json
+++ b/items/stitcher_i.json
@@ -180,12 +180,8 @@
   "salvagesInto": {
     "metal_parts": 3
   },
-  "upgradeCost": {
-    "metal_parts": 8,
-    "rubber_parts": 12
-  },
   "imageFilename": "https://cdn.arctracker.io/items/stitcher.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/stitcher_ii.json
+++ b/items/stitcher_ii.json
@@ -222,11 +222,11 @@
     "metal_parts": 6
   },
   "upgradeCost": {
-    "metal_parts": 10,
-    "simple_gun_parts": 1
+    "metal_parts": 8,
+    "rubber_parts": 12
   },
   "imageFilename": "https://cdn.arctracker.io/items/stitcher.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/stitcher_iii.json
+++ b/items/stitcher_iii.json
@@ -222,11 +222,11 @@
     "simple_gun_parts": 1
   },
   "upgradeCost": {
-    "mechanical_components": 3,
+    "metal_parts": 10,
     "simple_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/stitcher.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/synthesized_fuel.json
+++ b/items/synthesized_fuel.json
@@ -50,10 +50,6 @@
   "value": 700,
   "weightKg": 0.5,
   "stackSize": 5,
-  "craftBench": "in_raid",
-  "recipe": {
-    "rocket_thruster": 1
-  },
   "recyclesInto": {
     "chemicals": 1,
     "oil": 1
@@ -62,7 +58,7 @@
     "oil": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/synthesized_fuel.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/syringe.json
+++ b/items/syringe.json
@@ -50,10 +50,6 @@
   "value": 500,
   "weightKg": 0.3,
   "stackSize": 5,
-  "craftBench": "in_raid",
-  "recipe": {
-    "rusted_shut_medical_kit": 1
-  },
   "recyclesInto": {
     "chemicals": 2,
     "plastic_parts": 3
@@ -62,7 +58,7 @@
     "plastic_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/syringe.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/tactical_mk1.json
+++ b/items/tactical_mk1.json
@@ -134,7 +134,8 @@
     "plastic_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/tactical_i.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "plastic_parts": 3,
     "rubber_parts": 3

--- a/items/tactical_mk2.json
+++ b/items/tactical_mk2.json
@@ -134,7 +134,8 @@
     "electrical_components": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/tactical_i.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "electrical_components": 1,
     "magnet": 1

--- a/items/tactical_mk3_defensive.json
+++ b/items/tactical_mk3_defensive.json
@@ -135,7 +135,8 @@
     "electrical_components": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/tactical_mk3_defensive.png",
-  "updatedAt": "01/20/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "advanced_electrical_components": 1,
     "processor": 2

--- a/items/tactical_mk3_healing.json
+++ b/items/tactical_mk3_healing.json
@@ -135,7 +135,8 @@
     "electrical_components": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/tactical_mk3_healing.png",
-  "updatedAt": "01/20/2026",
+  "updatedAt": "03/17/2026",
+  "addedIn": "base",
   "repairCost": {
     "advanced_electrical_components": 1,
     "processor": 2

--- a/items/tactical_mk3_revival.json
+++ b/items/tactical_mk3_revival.json
@@ -135,5 +135,6 @@
     "electrical_components": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/tactical_mk3_revival.png",
-  "updatedAt": "02/24/2026"
+  "updatedAt": "03/17/2026",
+  "addedIn": "base"
 }

--- a/items/tempest_i.json
+++ b/items/tempest_i.json
@@ -182,12 +182,8 @@
   "salvagesInto": {
     "medium_gun_parts": 2
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 2,
-    "medium_gun_parts": 1
-  },
   "imageFilename": "https://cdn.arctracker.io/items/tempest.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/tempest_ii.json
+++ b/items/tempest_ii.json
@@ -223,10 +223,10 @@
   },
   "upgradeCost": {
     "advanced_mechanical_components": 2,
-    "medium_gun_parts": 3
+    "medium_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/tempest.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/torn_book.json
+++ b/items/torn_book.json
@@ -50,8 +50,7 @@
   "value": 1000,
   "weightKg": 0.3,
   "stackSize": 5,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/torn_book.png",
-  "updatedAt": "11/04/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/torrente_i.json
+++ b/items/torrente_i.json
@@ -182,12 +182,8 @@
   "salvagesInto": {
     "medium_gun_parts": 2
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 1,
-    "medium_gun_parts": 2
-  },
   "imageFilename": "https://cdn.arctracker.io/items/torrente.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "magazine": [

--- a/items/torrente_iii.json
+++ b/items/torrente_iii.json
@@ -199,11 +199,11 @@
     "medium_gun_parts": 3
   },
   "upgradeCost": {
-    "advanced_mechanical_components": 2,
+    "advanced_mechanical_components": 1,
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/torrente.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "magazine": [

--- a/items/tropical_duck.json
+++ b/items/tropical_duck.json
@@ -49,8 +49,7 @@
   "value": 1000,
   "weightKg": 0.3,
   "stackSize": 15,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/tropical_duck.png",
-  "updatedAt": "02/01/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "1.13"
 }

--- a/items/vase.json
+++ b/items/vase.json
@@ -50,8 +50,7 @@
   "value": 3000,
   "weightKg": 0.3,
   "stackSize": 3,
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/vase.png",
-  "updatedAt": "11/04/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/venator_i.json
+++ b/items/venator_i.json
@@ -205,12 +205,8 @@
   "salvagesInto": {
     "medium_gun_parts": 2
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 1,
-    "medium_gun_parts": 2
-  },
   "imageFilename": "https://cdn.arctracker.io/items/venator.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/venator_iii.json
+++ b/items/venator_iii.json
@@ -245,11 +245,11 @@
     "medium_gun_parts": 3
   },
   "upgradeCost": {
-    "advanced_mechanical_components": 2,
+    "advanced_mechanical_components": 1,
     "medium_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/venator.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/volcanic_rock.json
+++ b/items/volcanic_rock.json
@@ -75,8 +75,7 @@
       "zh-TW": "傷害"
     }
   },
-  "recyclesInto": {},
   "imageFilename": "https://cdn.arctracker.io/items/volcanic_rock.png",
-  "updatedAt": "10/30/2025",
+  "updatedAt": "03/17/2026",
   "addedIn": "base"
 }

--- a/items/voltage_converter.json
+++ b/items/voltage_converter.json
@@ -50,10 +50,6 @@
   "value": 500,
   "weightKg": 0.3,
   "stackSize": 5,
-  "craftBench": "in_raid",
-  "recipe": {
-    "signal_amplifier": 1
-  },
   "recyclesInto": {
     "rubber_parts": 1,
     "wires": 1
@@ -62,7 +58,7 @@
     "rubber_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/voltage_converter.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/vulcano_i.json
+++ b/items/vulcano_i.json
@@ -182,12 +182,8 @@
   "salvagesInto": {
     "heavy_gun_parts": 2
   },
-  "upgradeCost": {
-    "advanced_mechanical_components": 1,
-    "heavy_gun_parts": 2
-  },
   "imageFilename": "https://cdn.arctracker.io/items/vulcano.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "agility": 70.7,
   "damage": 58.5,

--- a/items/vulcano_ii.json
+++ b/items/vulcano_ii.json
@@ -222,11 +222,11 @@
     "heavy_gun_parts": 3
   },
   "upgradeCost": {
-    "advanced_mechanical_components": 2,
-    "heavy_gun_parts": 1
+    "advanced_mechanical_components": 1,
+    "heavy_gun_parts": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/vulcano.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "agility": 70.7,
   "damage": 58.5,

--- a/items/vulcano_iii.json
+++ b/items/vulcano_iii.json
@@ -269,10 +269,10 @@
   },
   "upgradeCost": {
     "advanced_mechanical_components": 2,
-    "heavy_gun_parts": 3
+    "heavy_gun_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/vulcano.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "modSlots": {
     "grip": [

--- a/items/wires.json
+++ b/items/wires.json
@@ -50,10 +50,6 @@
   "value": 200,
   "weightKg": 0.25,
   "stackSize": 15,
-  "craftBench": "in_raid",
-  "recipe": {
-    "power_cable": 1
-  },
   "recyclesInto": {
     "rubber_parts": 2
   },
@@ -61,7 +57,7 @@
     "rubber_parts": 1
   },
   "imageFilename": "https://cdn.arctracker.io/items/wires.png",
-  "updatedAt": "01/20/2026",
+  "updatedAt": "03/17/2026",
   "addedIn": "base",
   "tip": "Wires are an uncommon item used to craft weapon mods that can be recycled into crafting materials.",
   "vendors": [


### PR DESCRIPTION
Some things broken in 8c58170e2a0d2009a431e3d1f6d4b57d4be1b03b

* Weapon upgrade costs are on the target weapon, not the source.
* Many incorrect "In-Raid crafting" recipes removed
* Added more "addedIn" information
* Removed "blueprintLocked" to the "Traps" (those are skill locked)
* Added latest game addition (i.e. changed price for energy clip)

Updated with latest game-data as of today.