### PR TITLE
Updated trades with in game-data information

### DIFF
--- a/trades.json
+++ b/trades.json
@@ -58,6 +58,7 @@
       "quantity": 60
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 20
   },
   {
@@ -69,6 +70,7 @@
       "quantity": 55
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 20
   },
   {
@@ -80,6 +82,7 @@
       "quantity": 15
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -91,6 +94,7 @@
       "quantity": 15
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -102,6 +106,7 @@
       "quantity": 15
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -113,6 +118,7 @@
       "quantity": 10
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -124,6 +130,7 @@
       "quantity": 10
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -135,6 +142,7 @@
       "quantity": 10
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -146,6 +154,7 @@
       "quantity": 10
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -157,6 +166,7 @@
       "quantity": 10
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -168,6 +178,7 @@
       "quantity": 14
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -179,6 +190,7 @@
       "quantity": 10
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -190,6 +202,7 @@
       "quantity": 10
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -201,6 +214,7 @@
       "quantity": 5
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -212,6 +226,7 @@
       "quantity": 6
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -223,6 +238,7 @@
       "quantity": 6
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -234,6 +250,7 @@
       "quantity": 5
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -245,6 +262,7 @@
       "quantity": 6
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -256,6 +274,7 @@
       "quantity": 6
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -267,6 +286,7 @@
       "quantity": 7
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -278,6 +298,7 @@
       "quantity": 6
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -289,6 +310,7 @@
       "quantity": 4
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -360,6 +382,7 @@
       "quantity": 100
     },
     "dailyLimit": 2,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -371,6 +394,7 @@
       "quantity": 100
     },
     "dailyLimit": 2,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -382,6 +406,7 @@
       "quantity": 100
     },
     "dailyLimit": 2,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -392,7 +417,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -402,7 +428,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -412,7 +439,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -422,7 +450,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -432,7 +461,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -442,7 +472,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -452,7 +483,8 @@
       "itemId": "creds",
       "quantity": 50
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -462,7 +494,8 @@
       "itemId": "creds",
       "quantity": 40
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -472,7 +505,8 @@
       "itemId": "creds",
       "quantity": 40
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -483,6 +517,7 @@
       "quantity": 100
     },
     "dailyLimit": 2,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -493,7 +528,8 @@
       "itemId": "creds",
       "quantity": 60
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Shani",
@@ -504,6 +540,7 @@
       "quantity": 70
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -514,7 +551,8 @@
       "itemId": "creds",
       "quantity": 40
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Tian Wen",
@@ -587,6 +625,7 @@
       "quantity": 30000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 20
   },
   {
@@ -598,6 +637,7 @@
       "quantity": 21000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -609,6 +649,7 @@
       "quantity": 15000
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -620,6 +661,7 @@
       "quantity": 8700
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -631,6 +673,7 @@
       "quantity": 15000
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -642,6 +685,7 @@
       "quantity": 15000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -653,6 +697,7 @@
       "quantity": 6000
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -664,6 +709,7 @@
       "quantity": 6000
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -675,6 +721,7 @@
       "quantity": 1920
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -686,6 +733,7 @@
       "quantity": 1920
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -697,6 +745,7 @@
       "quantity": 1920
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -708,6 +757,7 @@
       "quantity": 1920
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -719,6 +769,7 @@
       "quantity": 1920
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -730,6 +781,7 @@
       "quantity": 1920
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -741,6 +793,7 @@
       "quantity": 1920
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -752,6 +805,7 @@
       "quantity": 1920
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -803,6 +857,7 @@
       "quantity": 6000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -813,7 +868,8 @@
       "itemId": "coins",
       "quantity": 8700
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Tian Wen",
@@ -824,6 +880,7 @@
       "quantity": 6000
     },
     "dailyLimit": 2,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -835,6 +892,7 @@
       "quantity": 15000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 20
   },
   {
@@ -916,7 +974,8 @@
       "itemId": "coins",
       "quantity": 3000
     },
-    "dailyLimit": 6
+    "dailyLimit": 6,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Apollo",
@@ -926,7 +985,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 6
+    "dailyLimit": 6,
+    "refreshSeconds": 86400
   },
   {
     "trader": "Apollo",
@@ -937,6 +997,7 @@
       "quantity": 3000
     },
     "dailyLimit": 6,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -948,6 +1009,7 @@
       "quantity": 1920
     },
     "dailyLimit": 6,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -959,6 +1021,7 @@
       "quantity": 2400
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -970,6 +1033,7 @@
       "quantity": 810
     },
     "dailyLimit": 6,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -981,6 +1045,7 @@
       "quantity": 18000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 20
   },
   {
@@ -992,6 +1057,7 @@
       "quantity": 2550
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1003,6 +1069,7 @@
       "quantity": 1410
     },
     "dailyLimit": 6,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1014,6 +1081,7 @@
       "quantity": 3000
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -1025,6 +1093,7 @@
       "quantity": 1920
     },
     "dailyLimit": 6,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1036,6 +1105,7 @@
       "quantity": 810
     },
     "dailyLimit": 6,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1047,6 +1117,7 @@
       "quantity": 6600
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1139,6 +1210,7 @@
       "quantity": 6000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1150,6 +1222,7 @@
       "quantity": 6000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1161,6 +1234,7 @@
       "quantity": 6000
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1172,6 +1246,7 @@
       "quantity": 16500
     },
     "dailyLimit": 1,
+    "refreshSeconds": 86400,
     "requiredLevel": 20
   },
   {
@@ -1183,6 +1258,7 @@
       "quantity": 6000
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -1194,6 +1270,7 @@
       "quantity": 6000
     },
     "dailyLimit": 3,
+    "refreshSeconds": 86400,
     "requiredLevel": 12
   },
   {
@@ -1205,6 +1282,7 @@
       "quantity": 3600
     },
     "dailyLimit": 5,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {
@@ -1216,6 +1294,7 @@
       "quantity": 2700
     },
     "dailyLimit": 10,
+    "refreshSeconds": 86400,
     "requiredLevel": 7
   },
   {

--- a/trades.json
+++ b/trades.json
@@ -57,7 +57,8 @@
       "itemId": "assorted_seeds",
       "quantity": 60
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 20
   },
   {
     "trader": "Celeste",
@@ -67,7 +68,8 @@
       "itemId": "assorted_seeds",
       "quantity": 55
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 20
   },
   {
     "trader": "Celeste",
@@ -77,7 +79,8 @@
       "itemId": "assorted_seeds",
       "quantity": 15
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -87,7 +90,8 @@
       "itemId": "assorted_seeds",
       "quantity": 15
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -97,7 +101,8 @@
       "itemId": "assorted_seeds",
       "quantity": 15
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -107,7 +112,8 @@
       "itemId": "assorted_seeds",
       "quantity": 10
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -117,7 +123,8 @@
       "itemId": "assorted_seeds",
       "quantity": 10
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -127,7 +134,8 @@
       "itemId": "assorted_seeds",
       "quantity": 10
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -137,7 +145,8 @@
       "itemId": "assorted_seeds",
       "quantity": 10
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -147,7 +156,8 @@
       "itemId": "assorted_seeds",
       "quantity": 10
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -157,7 +167,8 @@
       "itemId": "assorted_seeds",
       "quantity": 14
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -167,7 +178,8 @@
       "itemId": "assorted_seeds",
       "quantity": 10
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -177,7 +189,8 @@
       "itemId": "assorted_seeds",
       "quantity": 10
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 12
   },
   {
     "trader": "Celeste",
@@ -187,7 +200,8 @@
       "itemId": "assorted_seeds",
       "quantity": 5
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Celeste",
@@ -197,7 +211,8 @@
       "itemId": "assorted_seeds",
       "quantity": 6
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Celeste",
@@ -207,7 +222,8 @@
       "itemId": "assorted_seeds",
       "quantity": 6
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Celeste",
@@ -217,7 +233,8 @@
       "itemId": "assorted_seeds",
       "quantity": 5
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Celeste",
@@ -227,7 +244,8 @@
       "itemId": "assorted_seeds",
       "quantity": 6
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Celeste",
@@ -237,7 +255,8 @@
       "itemId": "assorted_seeds",
       "quantity": 6
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Celeste",
@@ -247,7 +266,8 @@
       "itemId": "assorted_seeds",
       "quantity": 7
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Celeste",
@@ -257,7 +277,8 @@
       "itemId": "assorted_seeds",
       "quantity": 6
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Celeste",
@@ -267,7 +288,8 @@
       "itemId": "assorted_seeds",
       "quantity": 4
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Shani",
@@ -337,7 +359,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "requiredLevel": 7
   },
   {
     "trader": "Shani",
@@ -347,7 +370,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "requiredLevel": 7
   },
   {
     "trader": "Shani",
@@ -357,7 +381,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "requiredLevel": 7
   },
   {
     "trader": "Shani",
@@ -457,7 +482,8 @@
       "itemId": "creds",
       "quantity": 100
     },
-    "dailyLimit": 2
+    "dailyLimit": 2,
+    "requiredLevel": 7
   },
   {
     "trader": "Shani",
@@ -466,6 +492,27 @@
     "cost": {
       "itemId": "creds",
       "quantity": 60
+    },
+    "dailyLimit": 3
+  },
+  {
+    "trader": "Shani",
+    "itemId": "acoustic_guitar",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 70
+    },
+    "dailyLimit": 1,
+    "requiredLevel": 12
+  },
+  {
+    "trader": "Shani",
+    "itemId": "shaker",
+    "quantity": 1,
+    "cost": {
+      "itemId": "creds",
+      "quantity": 40
     },
     "dailyLimit": 3
   },
@@ -517,7 +564,8 @@
       "itemId": "coins",
       "quantity": 3000
     },
-    "dailyLimit": null
+    "dailyLimit": null,
+    "requiredLevel": 12
   },
   {
     "trader": "Tian Wen",
@@ -527,7 +575,8 @@
       "itemId": "coins",
       "quantity": 4500
     },
-    "dailyLimit": null
+    "dailyLimit": null,
+    "requiredLevel": 12
   },
   {
     "trader": "Tian Wen",
@@ -537,7 +586,8 @@
       "itemId": "coins",
       "quantity": 30000
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 20
   },
   {
     "trader": "Tian Wen",
@@ -547,7 +597,8 @@
       "itemId": "coins",
       "quantity": 21000
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 12
   },
   {
     "trader": "Tian Wen",
@@ -557,7 +608,8 @@
       "itemId": "coins",
       "quantity": 15000
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -567,7 +619,8 @@
       "itemId": "coins",
       "quantity": 8700
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -577,7 +630,8 @@
       "itemId": "coins",
       "quantity": 15000
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -587,7 +641,8 @@
       "itemId": "coins",
       "quantity": 15000
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -597,7 +652,8 @@
       "itemId": "coins",
       "quantity": 6000
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -607,7 +663,8 @@
       "itemId": "coins",
       "quantity": 6000
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -617,7 +674,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -627,7 +685,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -637,7 +696,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -647,7 +707,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -657,7 +718,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -667,7 +729,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -677,17 +740,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 5
-  },
-  {
-    "trader": "Tian Wen",
-    "itemId": "stable_stock_i",
-    "quantity": 1,
-    "cost": {
-      "itemId": "coins",
-      "quantity": 1920
-    },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -697,7 +751,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Tian Wen",
@@ -738,6 +793,49 @@
       "quantity": 900
     },
     "dailyLimit": null
+  },
+  {
+    "trader": "Tian Wen",
+    "itemId": "silencer_i",
+    "quantity": 1,
+    "cost": {
+      "itemId": "coins",
+      "quantity": 6000
+    },
+    "dailyLimit": 1,
+    "requiredLevel": 7
+  },
+  {
+    "trader": "Tian Wen",
+    "itemId": "ferro_iv",
+    "quantity": 1,
+    "cost": {
+      "itemId": "coins",
+      "quantity": 8700
+    },
+    "dailyLimit": 1
+  },
+  {
+    "trader": "Tian Wen",
+    "itemId": "stable_stock_ii",
+    "quantity": 1,
+    "cost": {
+      "itemId": "coins",
+      "quantity": 6000
+    },
+    "dailyLimit": 2,
+    "requiredLevel": 7
+  },
+  {
+    "trader": "Tian Wen",
+    "itemId": "padded_stock",
+    "quantity": 1,
+    "cost": {
+      "itemId": "coins",
+      "quantity": 15000
+    },
+    "dailyLimit": 1,
+    "requiredLevel": 20
   },
   {
     "trader": "Apollo",
@@ -807,7 +905,8 @@
       "itemId": "coins",
       "quantity": 810
     },
-    "dailyLimit": null
+    "dailyLimit": null,
+    "requiredLevel": 7
   },
   {
     "trader": "Apollo",
@@ -831,23 +930,14 @@
   },
   {
     "trader": "Apollo",
-    "itemId": "heavy_fuze_grenade",
-    "quantity": 1,
-    "cost": {
-      "itemId": "coins",
-      "quantity": 4800
-    },
-    "dailyLimit": 3
-  },
-  {
-    "trader": "Apollo",
     "itemId": "smoke_grenade",
     "quantity": 1,
     "cost": {
       "itemId": "coins",
       "quantity": 3000
     },
-    "dailyLimit": 6
+    "dailyLimit": 6,
+    "requiredLevel": 7
   },
   {
     "trader": "Apollo",
@@ -857,7 +947,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 6
+    "dailyLimit": 6,
+    "requiredLevel": 7
   },
   {
     "trader": "Apollo",
@@ -867,7 +958,8 @@
       "itemId": "coins",
       "quantity": 2400
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 7
   },
   {
     "trader": "Apollo",
@@ -877,7 +969,8 @@
       "itemId": "coins",
       "quantity": 810
     },
-    "dailyLimit": 6
+    "dailyLimit": 6,
+    "requiredLevel": 7
   },
   {
     "trader": "Apollo",
@@ -885,9 +978,10 @@
     "quantity": 1,
     "cost": {
       "itemId": "coins",
-      "quantity": 15000
+      "quantity": 18000
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 20
   },
   {
     "trader": "Apollo",
@@ -897,7 +991,8 @@
       "itemId": "coins",
       "quantity": 2550
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 7
   },
   {
     "trader": "Apollo",
@@ -907,7 +1002,8 @@
       "itemId": "coins",
       "quantity": 1410
     },
-    "dailyLimit": 6
+    "dailyLimit": 6,
+    "requiredLevel": 7
   },
   {
     "trader": "Apollo",
@@ -917,7 +1013,8 @@
       "itemId": "coins",
       "quantity": 3000
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 12
   },
   {
     "trader": "Apollo",
@@ -927,7 +1024,8 @@
       "itemId": "coins",
       "quantity": 1920
     },
-    "dailyLimit": 6
+    "dailyLimit": 6,
+    "requiredLevel": 7
   },
   {
     "trader": "Apollo",
@@ -937,15 +1035,27 @@
       "itemId": "coins",
       "quantity": 810
     },
-    "dailyLimit": 6
+    "dailyLimit": 6,
+    "requiredLevel": 7
+  },
+  {
+    "trader": "Apollo",
+    "itemId": "trailblazer",
+    "quantity": 1,
+    "cost": {
+      "itemId": "coins",
+      "quantity": 6600
+    },
+    "dailyLimit": 3,
+    "requiredLevel": 7
   },
   {
     "trader": "Lance",
     "itemId": "looting_mk1",
     "quantity": 1,
     "cost": {
-      "itemId": "coins",
-      "quantity": 1920
+      "itemId": "free_loadout_augment",
+      "quantity": 1
     },
     "dailyLimit": null
   },
@@ -987,7 +1097,8 @@
       "itemId": "coins",
       "quantity": 3000
     },
-    "dailyLimit": null
+    "dailyLimit": null,
+    "requiredLevel": 7
   },
   {
     "trader": "Lance",
@@ -1027,7 +1138,8 @@
       "itemId": "coins",
       "quantity": 6000
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 7
   },
   {
     "trader": "Lance",
@@ -1037,7 +1149,8 @@
       "itemId": "coins",
       "quantity": 6000
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 7
   },
   {
     "trader": "Lance",
@@ -1047,7 +1160,8 @@
       "itemId": "coins",
       "quantity": 6000
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 7
   },
   {
     "trader": "Lance",
@@ -1057,7 +1171,8 @@
       "itemId": "coins",
       "quantity": 16500
     },
-    "dailyLimit": 1
+    "dailyLimit": 1,
+    "requiredLevel": 20
   },
   {
     "trader": "Lance",
@@ -1067,7 +1182,8 @@
       "itemId": "coins",
       "quantity": 6000
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 12
   },
   {
     "trader": "Lance",
@@ -1077,7 +1193,8 @@
       "itemId": "coins",
       "quantity": 6000
     },
-    "dailyLimit": 3
+    "dailyLimit": 3,
+    "requiredLevel": 12
   },
   {
     "trader": "Lance",
@@ -1087,7 +1204,8 @@
       "itemId": "coins",
       "quantity": 3600
     },
-    "dailyLimit": 5
+    "dailyLimit": 5,
+    "requiredLevel": 7
   },
   {
     "trader": "Lance",
@@ -1097,15 +1215,16 @@
       "itemId": "coins",
       "quantity": 2700
     },
-    "dailyLimit": 10
+    "dailyLimit": 10,
+    "requiredLevel": 7
   },
   {
     "trader": "Lance",
     "itemId": "looting_mk1",
     "quantity": 1,
     "cost": {
-      "itemId": "free_loadout_augment",
-      "quantity": 1
+      "itemId": "coins",
+      "quantity": 1920
     },
     "dailyLimit": null
   },


### PR DESCRIPTION
## Summary

Updated `trades.json` with in-game data information.

### `refreshSeconds` added to existing trades

The time it takes for an used offer to reset (usually 24h = 86400 seconds).

### `requiredLevel` added to existing trades

A `requiredLevel` field has been added to ~50 existing trades across all traders. Values used:
- **Level 7** — most common, applied to cheap/common items
- **Level 12** — mid-tier items (e.g. several Celeste seeds, some Lance attachments, Apollo `zipline`)
- **Level 20** — high-cost items (e.g. Celeste top-tier seeds, Lance & Apollo level-20 items)

### New trades added

**Shani**
- `acoustic_guitar` — 70 creds, limit 1/day, req. level 12
- `shaker` — 40 creds, limit 3/day

**Tian Wen**
- `silencer_i` — 6,000 coins, limit 1/day, req. level 7
- `ferro_iv` — 8,700 coins, limit 1/day
- `stable_stock_ii` — 6,000 coins, limit 2/day, req. level 7
- `padded_stock` — 15,000 coins, limit 1/day, req. level 20

**Apollo**
- `trailblazer` — 6,600 coins, limit 3/day, req. level 7

### Trades removed

- **Tian Wen** — `stable_stock_i` (1,920 coins, limit 5/day)
- **Apollo** — `heavy_fuze_grenade` (4,800 coins, limit 3/day)

### Price change

- **Apollo** `deadline`: 15,000 → 18,000 coins
