### PR TITLE
Updates from patch 1.24.0 - quest items now are value 100

### DIFF
--- a/items/celeste_journal.json
+++ b/items/celeste_journal.json
@@ -46,9 +46,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "imageFilename": "https://cdn.arctracker.io/items/celestes_journal.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/dodgers_note.json
+++ b/items/dodgers_note.json
@@ -46,10 +46,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
-  "updatedAt": "03/31/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.22"
 }

--- a/items/dusty_film_reel.json
+++ b/items/dusty_film_reel.json
@@ -46,9 +46,9 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0,
   "stackSize": 1,
-  "updatedAt": "03/17/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.17"
 }

--- a/items/espresso_machine_parts.json
+++ b/items/espresso_machine_parts.json
@@ -24,11 +24,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/espresso_machine_parts.png",
-  "updatedAt": "02/23/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/esr_analyzer.json
+++ b/items/esr_analyzer.json
@@ -46,10 +46,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/esr_analyzer.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/experimental_seed_sample.json
+++ b/items/experimental_seed_sample.json
@@ -46,10 +46,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/experimental_seed_sample.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/first_wave_compass.json
+++ b/items/first_wave_compass.json
@@ -46,10 +46,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/first_wave_compass.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/first_wave_rations.json
+++ b/items/first_wave_rations.json
@@ -46,10 +46,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/first_wave_rations.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/first_wave_tape.json
+++ b/items/first_wave_tape.json
@@ -46,10 +46,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/first_wave_tape.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/flushing_terminal_key.json
+++ b/items/flushing_terminal_key.json
@@ -46,10 +46,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "imageFilename": "https://cdn.arctracker.io/items/flushing_terminal_key.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.1"
 }

--- a/items/library_book.json
+++ b/items/library_book.json
@@ -24,10 +24,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
-  "updatedAt": "03/17/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/lidar_scanner.json
+++ b/items/lidar_scanner.json
@@ -46,9 +46,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "imageFilename": "https://cdn.arctracker.io/items/lidar_scanner.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/major_aivas_mementos.json
+++ b/items/major_aivas_mementos.json
@@ -24,11 +24,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/major_aivas_mementos.png",
-  "updatedAt": "03/17/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/major_aivas_patch.json
+++ b/items/major_aivas_patch.json
@@ -46,6 +46,7 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "effects": {
@@ -74,6 +75,6 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/major_aivas_patch.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/moisture_meter.json
+++ b/items/moisture_meter.json
@@ -46,10 +46,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/moisture_meter.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.7"
 }

--- a/items/nutrient_meter.json
+++ b/items/nutrient_meter.json
@@ -46,10 +46,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/nutrient_meter.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.7"
 }

--- a/items/official_shutdown_documentation.json
+++ b/items/official_shutdown_documentation.json
@@ -46,10 +46,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
-  "updatedAt": "03/31/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.22"
 }

--- a/items/old_world_books.json
+++ b/items/old_world_books.json
@@ -46,10 +46,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
   "imageFilename": "https://cdn.arctracker.io/items/old_world_books.png",
-  "updatedAt": "02/05/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.1"
 }

--- a/items/possibly_toxic_plant.json
+++ b/items/possibly_toxic_plant.json
@@ -24,11 +24,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/possibly_toxic_plant.png",
-  "updatedAt": "03/17/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "base"
 }

--- a/items/project_heartwood_blueprints.json
+++ b/items/project_heartwood_blueprints.json
@@ -46,9 +46,9 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0,
   "stackSize": 1,
-  "updatedAt": "03/17/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.17"
 }

--- a/items/scout_patrol_note.json
+++ b/items/scout_patrol_note.json
@@ -46,10 +46,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
-  "updatedAt": "03/31/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.22"
 }

--- a/items/secret_meeting_info.json
+++ b/items/secret_meeting_info.json
@@ -46,10 +46,10 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
-  "updatedAt": "03/31/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.22"
 }

--- a/items/stack_of_movie_tapes.json
+++ b/items/stack_of_movie_tapes.json
@@ -24,11 +24,11 @@
   },
   "type": "Trinket",
   "rarity": "Common",
-  "value": 0,
+  "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/stack_of_movie_tapes.png",
-  "updatedAt": "02/23/2026",
+  "updatedAt": "04/14/2026",
   "addedIn": "1.13"
 }


### PR DESCRIPTION
These items had no selling value before, now its 100:

- Celeste's Journal
- Dodger's Note
- Dusty Film Reel
- Espresso Machine Parts
- ESR Analyzer
- Experimental Seed Sample
- First Wave Compass
- First Wave Rations
- First Wave Tape
- Flushing Terminal Key
- Library Book
- Lidar Scanner
- Major Aiva's Mementos
- Major Aiva's Patch
- Moisture Meter
- Nutrient Meter
- Official Shutdown Documentation
- Old World Books
- Possibly Toxic Plant
- Project Heartwood Blueprints
- Scout Patrol Note
- Secret Meeting Info
- Stack of Movie Tapes

Curiosity, see here: https://www.reddit.com/r/ArcRaiders/comments/1si0f4n/ive_got_all_25_quest_items_in_my_stash_literally/