### PR TITLE
test: Add localized text type and associated tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,10 @@
   "workspaces": {
     "": {
       "name": "arcraiders-data",
+      "dependencies": {
+        "jsonpath-plus": "^10.4.0",
+        "zod": "^4.3.6",
+      },
       "devDependencies": {
         "prettier": "^3.6.2",
         "prettier-plugin-sort-json": "^4.1.1",
@@ -12,10 +16,20 @@
     },
   },
   "packages": {
+    "@jsep-plugin/assignment": ["@jsep-plugin/assignment@1.3.0", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ=="],
+
+    "@jsep-plugin/regex": ["@jsep-plugin/regex@1.0.4", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="],
+
+    "jsep": ["jsep@1.4.0", "", {}, "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="],
+
+    "jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
+
     "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
     "prettier-plugin-sort-json": ["prettier-plugin-sort-json@4.1.1", "", { "peerDependencies": { "prettier": "^3.0.0" } }, "sha512-uJ49wCzwJ/foKKV4tIPxqi4jFFvwUzw4oACMRG2dcmDhBKrxBv0L2wSKkAqHCmxKCvj0xcCZS4jO2kSJO/tRJw=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
     "prettier-plugin-sort-json": "^4.1.1",
     "safe-stable-stringify": "^2.5.0"
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "jsonpath-plus": "^10.4.0",
+    "zod": "^4.3.6"
+  }
 }

--- a/src/types/localized-text.ts
+++ b/src/types/localized-text.ts
@@ -1,0 +1,53 @@
+import * as z from "zod"; // https://zod.dev/basics
+
+// TODO: When the arctracker-ui directory is normalized to use "ko-KR" as the locale
+// key for Korean, we can rename this to LocalizedText and remove the other private schemas.
+const LocalizedTextCanonical = z
+  .object({
+    // Match the locales defined by:
+    //  https://github.com/RaidTheory/arcraiders-data/tree/main/arctracker-ui
+    da: z.string(),
+    de: z.string(),
+    en: z.string(),
+    es: z.string(),
+    fr: z.string(),
+    he: z.string(),
+    hr: z.string(),
+    it: z.string(),
+    ja: z.string(),
+    "ko-KR": z.string(),
+    no: z.string(),
+    pl: z.string(),
+    "pt-BR": z.string(),
+    pt: z.string(),
+    ru: z.string(),
+    sr: z.string(),
+    tr: z.string(),
+    uk: z.string(),
+    "zh-CN": z.string(),
+    "zh-TW": z.string()
+  })
+  .describe("LocalizedTextCanonical");
+
+const LocalizedTextRaw = LocalizedTextCanonical.extend({
+  ko: z.string().optional(),
+  "ko-KR": z.string().optional(),
+  kr: z.string().optional()
+}).describe("LocalizedTextRaw");
+
+export const LocalizedText = LocalizedTextRaw.transform((data) => {
+  const { ko, ["ko-KR"]: _koKR, kr, ...rest } = data;
+
+  return {
+    ...rest,
+    "ko-KR": _koKR ?? ko ?? kr
+  };
+})
+  .pipe(LocalizedTextCanonical.strict())
+  .describe("LocalizedText");
+
+// Private data exported for testing purposes only. Not intended for public use.
+export const __internal__ = {
+  LocalizedTextCanonical,
+  LocalizedTextRaw
+};

--- a/test/localized-text.test.ts
+++ b/test/localized-text.test.ts
@@ -1,0 +1,327 @@
+import * as lt from "../src/types/localized-text";
+import { test, expect } from "bun:test";
+import * as z from "zod"; // https://zod.dev/basics
+import { Glob } from "bun";
+import { basename, resolve } from "path";
+import { JSONPath } from "jsonpath-plus";
+
+const root = resolve(import.meta.dir, "..");
+
+// While the exported types are not strict, it is good to have a strict version
+// of the schema for testing purposes to verify that all expected locales are
+// present and that there are no unrecognized keys. This ensures that new locales
+// are added to the type and tests will surface instances where translations may be missing
+// from various entities like items, maps, and projects.
+const LocalizedTextStrict =
+  lt.__internal__.LocalizedTextCanonical.strict().describe(
+    "LocalizedTextStrict"
+  );
+
+function getParseError(result: z.ZodSafeParseResult<any>): string | undefined {
+  if (result.success) {
+    return undefined;
+  }
+  const prettyError = z.prettifyError(result.error);
+  return prettyError;
+}
+
+function getNumLocalizedTextInstances(json: string): number {
+  // TODO: Note that we can expand this to `(@.en && @.es)` or similar when xfail issues
+  // are addressed (i.e. Hurricane map condition excluding all but english translation)
+  return JSONPath({
+    path: "$..[?(@.en)]",
+    json: json
+  }).length;
+}
+
+test("xfail: validate locale directories match LocalizedText struct", async () => {
+  const glob = new Glob(`${root}/arctracker-ui/*.json`);
+  const actualLocales = new Set<string>();
+  for await (const path of glob.scan()) {
+    const locale = basename(path, ".json");
+    actualLocales.add(locale);
+  }
+  const expectedLocales = new Set<string>(
+    Object.keys(LocalizedTextStrict.shape)
+  );
+  expect(actualLocales.size).toEqual(expectedLocales.size);
+  var errorCount = 0;
+  for (const locale of expectedLocales) {
+    if (!actualLocales.has(locale)) {
+      console.error(`Locale ${locale} is missing from arctracker-ui directory`);
+      ++errorCount;
+    }
+  }
+  expect(errorCount).toBe(1); // Remove xfail when this is 0
+});
+
+test("validate strict schema w/ small trinket item", () => {
+  const path = `${root}/items/library_book.json`;
+  const data = require(path);
+  expect(getParseError(LocalizedTextStrict.safeParse(data.name))).toBe(
+    undefined
+  );
+});
+
+test("xfail: validate strict schema w/ all maps", async () => {
+  const xfailError = `✖ Invalid input: expected string, received undefined
+  → at he`;
+  const maps = require(`${root}/maps.json`);
+  const expectedNumEvaluations = getNumLocalizedTextInstances(maps);
+  var errorCount = 0;
+  var numEvaluations = 0;
+  for (const map of maps) {
+    const error = getParseError(LocalizedTextStrict.safeParse(map.name));
+    if (error) {
+      console.error(`Validation failed for ${map.id}, ${error}`);
+      expect(error).toBe(xfailError);
+      ++errorCount;
+    }
+    ++numEvaluations;
+  }
+  expect(errorCount).toBe(6); // Remove xfail when this is 0
+  expect(numEvaluations).toBe(expectedNumEvaluations);
+});
+
+test("validate strict schema w/ all projects", async () => {
+  interface Project {
+    id: string;
+    name: z.infer<typeof lt.LocalizedText>;
+    description: z.infer<typeof lt.LocalizedText>;
+    phases: {
+      name: z.infer<typeof lt.LocalizedText>;
+      description: z.infer<typeof lt.LocalizedText>;
+      phase: number;
+      requirementCategories?: {
+        localizations: z.infer<typeof lt.LocalizedText>;
+      }[];
+    }[];
+  }
+  const projects = require(`${root}/projects.json`);
+  const expectedNumEvaluations = getNumLocalizedTextInstances(projects);
+  var errorCount = 0;
+  var numEvaluations = 0;
+  for (const project of projects as Project[]) {
+    var error = getParseError(LocalizedTextStrict.safeParse(project.name));
+    ++numEvaluations;
+    if (error) {
+      console.error(`Validation failed for ${project.id}->name, ${error}`);
+      ++errorCount;
+    }
+    error = getParseError(LocalizedTextStrict.safeParse(project.description));
+    ++numEvaluations;
+    if (error) {
+      console.error(
+        `Validation failed for ${project.id}->description, ${error}`
+      );
+      ++errorCount;
+    }
+    if (project.phases && project.phases.length > 0) {
+      for (const phase of project.phases) {
+        error = getParseError(LocalizedTextStrict.safeParse(phase.name));
+        ++numEvaluations;
+        if (error) {
+          console.error(
+            `Validation failed for ${project.id}->${phase.name.en}->name, ${error}`
+          );
+          ++errorCount;
+        }
+        error = getParseError(LocalizedTextStrict.safeParse(phase.description));
+        ++numEvaluations;
+        if (error) {
+          console.error(
+            `Validation failed for ${project.id}->${phase.name.en}->description, ${error}`
+          );
+          ++errorCount;
+        }
+        if (phase.requirementCategories) {
+          for (const category of phase.requirementCategories) {
+            const error = getParseError(
+              LocalizedTextStrict.safeParse(category.localizations)
+            );
+            ++numEvaluations;
+            if (error) {
+              console.error(
+                `Validation failed for ${project.id}->${phase.name.en}->${category.localizations.en}, ${error}`
+              );
+              ++errorCount;
+            }
+          }
+        }
+      }
+    }
+  }
+  expect(errorCount).toBe(0);
+  expect(numEvaluations).toBe(expectedNumEvaluations);
+});
+
+test("validate strict schema w/ all skills", async () => {
+  interface Skill {
+    id: string;
+    name: z.infer<typeof lt.LocalizedText>;
+    description: z.infer<typeof lt.LocalizedText>;
+    impactedSkill: z.infer<typeof lt.LocalizedText>;
+  }
+  const skills = require(`${root}/skillNodes.json`);
+  const expectedNumEvaluations = getNumLocalizedTextInstances(skills);
+  var errorCount = 0;
+  var numEvaluations = 0;
+  for (const skill of skills as Skill[]) {
+    var error = getParseError(LocalizedTextStrict.safeParse(skill.name));
+    ++numEvaluations;
+    if (error) {
+      console.error(`Validation failed for ${skill.id}->name, ${error}`);
+      ++errorCount;
+    }
+    error = getParseError(LocalizedTextStrict.safeParse(skill.description));
+    ++numEvaluations;
+    if (error) {
+      console.error(`Validation failed for ${skill.id}->description, ${error}`);
+      ++errorCount;
+    }
+    error = getParseError(LocalizedTextStrict.safeParse(skill.impactedSkill));
+    ++numEvaluations;
+    if (error) {
+      console.error(
+        `Validation failed for ${skill.id}->impactedSkill, ${error}`
+      );
+      ++errorCount;
+    }
+  }
+  expect(errorCount).toBe(0);
+  expect(numEvaluations).toBe(expectedNumEvaluations);
+});
+
+test("validate strict schema w/ all hideouts", async () => {
+  const glob = new Glob(`${root}/hideout/*.json`);
+  var errorCount = 0;
+  var expectedNumEvaluations = 0;
+  var numEvaluations = 0;
+  for await (const path of glob.scan()) {
+    const data = require(path);
+    expectedNumEvaluations += getNumLocalizedTextInstances(data);
+    const error = getParseError(LocalizedTextStrict.safeParse(data.name));
+    ++numEvaluations;
+    if (error) {
+      console.error(`Validation failed for ${data.id}, ${error}`);
+      ++errorCount;
+    }
+  }
+  expect(errorCount).toBe(0);
+  expect(numEvaluations).toBe(expectedNumEvaluations);
+});
+
+test("xfail: validate strict schema w/ all items", async () => {
+  const xfailError = `✖ Unrecognized key: "kr"
+✖ Invalid input: expected string, received undefined
+  → at ["ko-KR"]`;
+  const glob = new Glob(`${root}/items/*.json`);
+  var errorCount = 0;
+  for await (const path of glob.scan()) {
+    const data = require(path);
+    const error = getParseError(LocalizedTextStrict.safeParse(data.name));
+    if (error) {
+      console.error(`Validation failed for ${data.id}, ${error}`);
+      expect(error).toBe(xfailError);
+      ++errorCount;
+    }
+    if (data.description) {
+      const error = getParseError(
+        LocalizedTextStrict.safeParse(data.description)
+      );
+      if (error) {
+        console.error(
+          `Validation failed for ${data.id}->description, ${error}`
+        );
+        expect(error).toBe(xfailError);
+        ++errorCount;
+      }
+    }
+  }
+  expect(errorCount).toBe(12); // Remove xfail when this is 0
+});
+
+// The value of this test relative to the previous one is
+// that it verifies that we can coerce the non-canonical "ko" and "kr" keys to
+// "ko-KR" in the raw schema. Once the preceding strict check passes, we can
+// consider removing this test and the non-canonical keys from the raw schema.
+test("validate schema w/ all items", async () => {
+  const glob = new Glob(`${root}/items/*.json`);
+  var errorCount = 0;
+  for await (const path of glob.scan()) {
+    const data = require(path);
+    const error = getParseError(lt.LocalizedText.safeParse(data.name));
+    if (error) {
+      console.error(`Validation failed for ${path}.name, ${error}`);
+      ++errorCount;
+    }
+    if (data.description) {
+      const error = getParseError(lt.LocalizedText.safeParse(data.description));
+      if (error) {
+        console.error(`Validation failed for ${path}.description, ${error}`);
+        ++errorCount;
+      }
+    }
+  }
+  expect(errorCount).toBe(0);
+});
+
+test("xfail: validate strict schema w/ all map events", async () => {
+  interface MapEvent {
+    localizations: z.infer<typeof lt.LocalizedText>;
+  }
+  const events = require(`${root}/map-events/map-events.json`);
+  const expectedNumEvaluations = getNumLocalizedTextInstances(events);
+  var errorCount = 0;
+  var numEvaluations = 0;
+  for (const [name, instance] of Object.entries(events.eventTypes) as [
+    string,
+    MapEvent
+  ][]) {
+    const error = getParseError(
+      LocalizedTextStrict.safeParse(instance.localizations)
+    );
+    ++numEvaluations;
+    if (error) {
+      console.error(`Validation failed for map event ${name}, ${error}`);
+      ++errorCount;
+    }
+  }
+  expect(errorCount).toBe(15); // Remove xfail when this is 0
+  expect(numEvaluations).toBe(expectedNumEvaluations);
+});
+
+test("validate strict schema w/ all quests", async () => {
+  const glob = new Glob(`${root}/quests/*.json`);
+  var errorCount = 0;
+  var expectedNumEvaluations = 0;
+  var numEvaluations = 0;
+  for await (const path of glob.scan()) {
+    const data = require(path);
+    expectedNumEvaluations += getNumLocalizedTextInstances(data);
+    var error = getParseError(LocalizedTextStrict.safeParse(data.name));
+    ++numEvaluations;
+    if (error) {
+      console.error(`Validation failed for ${data.id}.name, ${error}`);
+      ++errorCount;
+    }
+    error = getParseError(LocalizedTextStrict.safeParse(data.description));
+    ++numEvaluations;
+    if (error) {
+      console.error(`Validation failed for ${data.id}.description, ${error}`);
+      ++errorCount;
+    }
+    for (const [index, objective] of data.objectives.entries()) {
+      const error = getParseError(LocalizedTextStrict.safeParse(objective));
+      ++numEvaluations;
+      if (error) {
+        console.error(
+          `Validation failed for ${data.id}.objectives[${index}], ${error}`
+        );
+        ++errorCount;
+      }
+    }
+  }
+  expect(errorCount).toBe(0);
+  expect(numEvaluations).toBe(expectedNumEvaluations);
+});


### PR DESCRIPTION
@baschny : I deconflated this out of https://github.com/RaidTheory/arcraiders-data/pull/287, per your [request](https://github.com/RaidTheory/arcraiders-data/pull/287#issuecomment-4246791482). From your comment there, understood that this may be controversial, but also noting some of the complexity in the schemas is driven by coercing a consistent output data type from inconsistent input data. This means that much of code can be deleted when data in the JSONs is made to match the canonical type.