### PR TITLE
fix: heavy ammo stack

### DIFF
--- a/items/heavy_ammo.json
+++ b/items/heavy_ammo.json
@@ -48,7 +48,7 @@
   "rarity": "Common",
   "value": 12,
   "weightKg": 0.05,
-  "stackSize": 40,
+  "stackSize": 60,
   "craftQuantity": 10,
   "compatibleWith": ["Anvil", "Ferro", "Bettina"],
   "craftBench": "workbench",


### PR DESCRIPTION
Updating the new heavy ammo stack from 40 to 60.