### PR TITLE
Updated more items of Riven Tide update

### DIFF
--- a/items/heavy_ammo.json
+++ b/items/heavy_ammo.json
@@ -48,7 +48,7 @@
   "rarity": "Common",
   "value": 12,
   "weightKg": 0.05,
-  "stackSize": 40,
+  "stackSize": 60,
   "craftQuantity": 10,
   "compatibleWith": ["Anvil", "Ferro", "Bettina"],
   "craftBench": "workbench",
@@ -58,7 +58,7 @@
     "metal_parts": 3
   },
   "imageFilename": "https://cdn.arctracker.io/items/heavy_ammo.png",
-  "updatedAt": "02/24/2026",
+  "updatedAt": "04/28/2026",
   "addedIn": "base",
   "vendors": [
     {

--- a/items/powered_descender.json
+++ b/items/powered_descender.json
@@ -53,7 +53,8 @@
   "craftBench": "utility_bench",
   "stationLevelRequired": 3,
   "recipe": {
-    "power_rod": 1
+    "power_rod": 1,
+    "turbine_compressor": 1
   },
   "recyclesInto": {
     "advanced_electrical_components": 1,

--- a/items/tactical_mk3_smoke_blueprint.json
+++ b/items/tactical_mk3_smoke_blueprint.json
@@ -51,5 +51,5 @@
   "stackSize": 1,
   "imageFilename": "https://cdn.arctracker.io/items/tactical_mk3_smoke_blueprint.png",
   "updatedAt": "04/28/2026",
-  "addedIn": "base"
+  "addedIn": "1.26"
 }

--- a/items/turbine_compressor.json
+++ b/items/turbine_compressor.json
@@ -25,7 +25,7 @@
   "description": {
     "da": "",
     "de": "",
-    "en": "",
+    "en": "Can be recycled into crafting materials.",
     "es": "",
     "fr": "",
     "he": "",
@@ -47,7 +47,16 @@
   "type": "Recyclable",
   "rarity": "Epic",
   "foundIn": "ARC",
+  "value": 5000,
+  "weightKg": 0.5,
   "stackSize": 3,
+  "recyclesInto": {
+    "arc_circuitry": 1,
+    "arc_motion_core": 1
+  },
+  "salvagesInto": {
+    "arc_circuitry": 1
+  },
   "updatedAt": "04/28/2026",
   "addedIn": "1.26"
 }

--- a/items/vaporizer_regulator.json
+++ b/items/vaporizer_regulator.json
@@ -48,7 +48,7 @@
   "rarity": "Epic",
   "value": 6000,
   "weightKg": 0.5,
-  "stackSize": 1,
+  "stackSize": 3,
   "recyclesInto": {
     "advanced_electrical_components": 1,
     "arc_circuitry": 2

--- a/items/wasp_driver.json
+++ b/items/wasp_driver.json
@@ -99,14 +99,13 @@
     }
   },
   "recyclesInto": {
-    "arc_alloy": 1,
-    "electrical_components": 1
+    "arc_alloy": 2
   },
   "salvagesInto": {
     "arc_alloy": 2
   },
   "imageFilename": "https://cdn.arctracker.io/items/wasp_driver.png",
-  "updatedAt": "01/13/2026",
+  "updatedAt": "04/28/2026",
   "addedIn": "base",
   "tip": "The Wasp Driver is a rare item is dropped by Wasps that can be recycled into crafting materials."
 }

--- a/items/white_flag.json
+++ b/items/white_flag.json
@@ -50,7 +50,7 @@
   "weightKg": 0.2,
   "stackSize": 5,
   "blueprintLocked": true,
-  "craftBench": "medical_lab",
+  "craftBench": ["med_station", "in_raid"],
   "stationLevelRequired": 1,
   "recipe": {
     "fabric": 10,


### PR DESCRIPTION
- Updated Heavy Ammo stack size from 40 to 60
- Added Turbine Compressor to the Powered Descender recipe.
- Marked Tactical Mk. 3 Smoke Blueprint as added in `1.26`
- Completed Turbine Compressor item data with description, value, weight, recycle outputs, and salvage output.
- Updated Vaporizer Regulator stack size from 1 to 3.
- Corrected Wasp Driver recycling output to 2 Arc Alloy.
- Fixed White Flag crafting bench availability.
