### PR TITLE
Fix required items for phase 3 of expedition 4

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2417,7 +2417,7 @@
         "phase": 5,
         "requirementItemIds": [
           {
-            "itemId": "monolith_part",
+            "itemId": "turbine_compressor",
             "quantity": 2
           },
           {
@@ -2672,7 +2672,7 @@
             "quantity": 15
           },
           {
-            "itemId": "monolith_part",
+            "itemId": "turbine_compressor",
             "quantity": 5
           },
           {


### PR DESCRIPTION
Also wrong in Avian Alarm, phase 5. "Monolith Part" is just an internal name in the game-data.