### PR TITLE
Add missing "value" JSON field in raider_flag

### DIFF
--- a/items/raider_flag.json
+++ b/items/raider_flag.json
@@ -47,9 +47,10 @@
   "type": "Trinket",
   "rarity": "Common",
   "weightKg": 0.5,
+  "value": 0,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/raider_flag.png",
-  "updatedAt": "05/04/2026",
+  "updatedAt": "05/23/2026",
   "addedIn": "base"
 }

--- a/items/raider_flag.json
+++ b/items/raider_flag.json
@@ -47,7 +47,7 @@
   "type": "Trinket",
   "rarity": "Common",
   "weightKg": 0.5,
-  "value": 0,
+  "value": 100,
   "stackSize": 1,
   "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/raider_flag.png",


### PR DESCRIPTION
All items/*.json files except raider_flag has a "value" field. For easier parsing and normalization, I have set the field to have a value of 0.