### PR TITLE
Fix questItem value on several items

### DIFF
--- a/items/celeste_journal.json
+++ b/items/celeste_journal.json
@@ -49,7 +49,8 @@
   "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
+  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/celeste_journal.png",
-  "updatedAt": "04/14/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "base"
 }

--- a/items/dusty_film_reel.json
+++ b/items/dusty_film_reel.json
@@ -49,7 +49,8 @@
   "value": 100,
   "weightKg": 0,
   "stackSize": 1,
+  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/dusty_film_reel.png",
-  "updatedAt": "04/14/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.17"
 }

--- a/items/flushing_terminal_key.json
+++ b/items/flushing_terminal_key.json
@@ -49,7 +49,8 @@
   "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
+  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/flushing_terminal_key.png",
-  "updatedAt": "04/14/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.1"
 }

--- a/items/lidar_scanner.json
+++ b/items/lidar_scanner.json
@@ -49,7 +49,8 @@
   "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
+  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/lidar_scanner.png",
-  "updatedAt": "04/14/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "base"
 }

--- a/items/major_aivas_patch.json
+++ b/items/major_aivas_patch.json
@@ -49,6 +49,7 @@
   "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
+  "questItem": true,
   "effects": {
     "Tracked for quest": {
       "value": "",
@@ -75,6 +76,6 @@
     }
   },
   "imageFilename": "https://cdn.arctracker.io/items/v2/major_aivas_patch.png",
-  "updatedAt": "04/14/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "base"
 }

--- a/items/old_world_books.json
+++ b/items/old_world_books.json
@@ -49,7 +49,8 @@
   "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
+  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/old_world_books.png",
-  "updatedAt": "04/14/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.1"
 }

--- a/items/project_heartwood_blueprints.json
+++ b/items/project_heartwood_blueprints.json
@@ -49,7 +49,8 @@
   "value": 100,
   "weightKg": 0,
   "stackSize": 1,
+  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/project_heartwood_blueprints.png",
-  "updatedAt": "04/14/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.17"
 }

--- a/items/riven_tides_crane_house_keycard.json
+++ b/items/riven_tides_crane_house_keycard.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_crane_house_keycard.png",
-  "updatedAt": "05/02/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }

--- a/items/riven_tides_hotel_keycard_no_102.json
+++ b/items/riven_tides_hotel_keycard_no_102.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_hotel_keycard_no_102.png",
-  "updatedAt": "05/02/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }

--- a/items/riven_tides_hotel_keycard_no_107.json
+++ b/items/riven_tides_hotel_keycard_no_107.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_hotel_keycard_no_107.png",
-  "updatedAt": "04/28/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }

--- a/items/riven_tides_hotel_keycard_no_113.json
+++ b/items/riven_tides_hotel_keycard_no_113.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_hotel_keycard_no_113.png",
-  "updatedAt": "05/02/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }

--- a/items/riven_tides_hotel_keycard_no_205.json
+++ b/items/riven_tides_hotel_keycard_no_205.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_hotel_keycard_no_205.png",
-  "updatedAt": "05/02/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }

--- a/items/riven_tides_hotel_keycard_no_208.json
+++ b/items/riven_tides_hotel_keycard_no_208.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_hotel_keycard_no_208.png",
-  "updatedAt": "05/02/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }

--- a/items/riven_tides_hotel_keycard_no_311.json
+++ b/items/riven_tides_hotel_keycard_no_311.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_hotel_keycard_no_311.png",
-  "updatedAt": "04/28/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }

--- a/items/riven_tides_hotel_keycard_no_404.json
+++ b/items/riven_tides_hotel_keycard_no_404.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.5,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_hotel_keycard_no_404.png",
-  "updatedAt": "05/02/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }

--- a/items/riven_tides_secure_storage_keycard.json
+++ b/items/riven_tides_secure_storage_keycard.json
@@ -49,8 +49,7 @@
   "value": 100,
   "weightKg": 0.25,
   "stackSize": 1,
-  "questItem": true,
   "imageFilename": "https://cdn.arctracker.io/items/v2/riven_tides_secure_storage_keycard.png",
-  "updatedAt": "05/02/2026",
+  "updatedAt": "06/03/2026",
   "addedIn": "1.26"
 }


### PR DESCRIPTION
A `questItem` is an item which we don't need to either track or seek for because they are usually found during a quest and consumed during that quest (or delivered to a vendor when you come back). So these mark should remove them from any "tracking item" list.

Some items had this wrongly marked, this is fixed here.